### PR TITLE
apply vitejs/vite@dfdb9cc

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -335,14 +335,14 @@ export default defineConfig(async ({ command, mode }) => {
 
 ### envPrefix
 
-- **Type:** `string | string[]`
-- **Default:** `VITE_`
+- **型:** `string | string[]`
+- **デフォルト:** `VITE_`
 
-  Env variables starts with `envPrefix` will be exposed to your client source code via import.meta.env.
+  `envPrefix` で始まる環境変数は、import.meta.env でクライアントのソースコードに公開されます。
 
 :::warning SECURITY NOTES
 
-- `envPrefix` should not be set as `''`, which will expose all your env variables and cause unexpected leaking of of sensitive information. Vite will throw error when detecting `''`.
+- `envPrefix` に `''` を設定してはいけません。全ての env 変数を公開してしまい、予期せぬ機密情報の漏洩を引き起こします。Vite は `''` を検出するとエラーをスローします。
   :::
 
 ## サーバオプション

--- a/config/index.md
+++ b/config/index.md
@@ -333,6 +333,18 @@ export default defineConfig(async ({ command, mode }) => {
 
   環境ファイルの詳細については[こちら](/guide/env-and-mode#env-files)をご覧ください。
 
+### envPrefix
+
+- **Type:** `string | string[]`
+- **Default:** `VITE_`
+
+  Env variables starts with `envPrefix` will be exposed to your client source code via import.meta.env.
+
+:::warning SECURITY NOTES
+
+- `envPrefix` should not be set as `''`, which will expose all your env variables and cause unexpected leaking of of sensitive information. Vite will throw error when detecting `''`.
+  :::
+
 ## サーバオプション
 
 ### server.host

--- a/guide/env-and-mode.md
+++ b/guide/env-and-mode.md
@@ -44,6 +44,8 @@ VITE_SOME_KEY=123
 
 `VITE_SOME_KEY` だけが `import.meta.env.VITE_SOME_KEY` としてクライアントソースコードに公開され、`DB_PASSWORD` は公開されません。
 
+If you want to customize env variables prefix, see [envPrefix](/config/index#envPrefix) option.
+
 :::warning SECURITY NOTES
 
 - `.env.*.local` ファイルはローカル限定で、センシティブな変数を含めることができます。git にチェックインされるのを防ぐために、`.gitignore` に `.local` を追加すべきです。

--- a/guide/env-and-mode.md
+++ b/guide/env-and-mode.md
@@ -44,7 +44,7 @@ VITE_SOME_KEY=123
 
 `VITE_SOME_KEY` だけが `import.meta.env.VITE_SOME_KEY` としてクライアントソースコードに公開され、`DB_PASSWORD` は公開されません。
 
-環境変数のプレフィックスをカスタマイズしたい場合は、[envPrefix](/config/index#envPrefix) オプションを参照してください。
+環境変数のプレフィックスをカスタマイズしたい場合は、[envPrefix](/config/index#envprefix) オプションを参照してください。
 
 :::warning SECURITY NOTES
 

--- a/guide/env-and-mode.md
+++ b/guide/env-and-mode.md
@@ -44,7 +44,7 @@ VITE_SOME_KEY=123
 
 `VITE_SOME_KEY` だけが `import.meta.env.VITE_SOME_KEY` としてクライアントソースコードに公開され、`DB_PASSWORD` は公開されません。
 
-If you want to customize env variables prefix, see [envPrefix](/config/index#envPrefix) option.
+環境変数のプレフィックスをカスタマイズしたい場合は、[envPrefix](/config/index#envPrefix) オプションを参照してください。
 
 :::warning SECURITY NOTES
 


### PR DESCRIPTION
resolves #98 
vitejs/vite@dfdb9cc の対応です

差分取り込み https://github.com/vitejs/docs-ja/commit/46bbf3f16d65fd2c310667db831283edbb690c1a と翻訳 https://github.com/vitejs/docs-ja/commit/954b83838ef4053d53df86a3f3b8bafe658a4284 でコミット分けてます

---
resolves #103 
vitejs/vite@74af8c4 も含めました
（リンク URL `envPrefix` → `envprefix`）