### PR TITLE
docs: add missing `prune` api in HMR

### DIFF
--- a/guide/api-hmr.md
+++ b/guide/api-hmr.md
@@ -18,6 +18,7 @@ interface ImportMeta {
     accept(dep: string, cb: (mod: any) => void): void
     accept(deps: string[], cb: (mods: any[]) => void): void
 
+    prune(cb: () => void): void
     dispose(cb: (data: any) => void): void
     decline(): void
     invalidate(): void


### PR DESCRIPTION
resolves #172 

vitejs/vite@12ee156 の適用