### PR TITLE
        feat: `server.fs.deny` support    

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -594,12 +594,12 @@ createServer()
 
 ### server.fs.deny
 
-- **Experimental**
-- **Type:** `string[]`
+- **実験的機能**
+- **型:** `string[]`
 
-  Blocklist for sensitive files being restricted to be served by Vite dev server.
+  Vite 開発サーバでの配信が制限されている機密ファイルのブロックリスト。
 
-  Default to `['.env', '.env.*', '*.{pem,crt}']`.
+  デフォルトは `['.env', '.env.*', '*.{pem,crt}']` です。
 
 ### server.origin
 

--- a/config/index.md
+++ b/config/index.md
@@ -592,6 +592,15 @@ createServer()
   })
   ```
 
+### server.fs.deny
+
+- **Experimental**
+- **Type:** `string[]`
+
+  Blocklist for sensitive files being restricted to be served by Vite dev server.
+
+  Default to `['.env', '.env.*', '*.{pem,crt}']`.
+
 ### server.origin
 
 - **型:** `string`


### PR DESCRIPTION
resolves #175 

vitejs/vite@1a15460 の適用と翻訳
ドキュメントの変更は1ファイルのみ