### PR TITLE
docs: css.modules.localsConvention is null by default

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -238,7 +238,12 @@ export default defineConfig(async ({ command, mode }) => {
     /**
      * デフォルト: null
      */
-    localsConvention?: 'camelCase' | 'camelCaseOnly' | 'dashes' | 'dashesOnly'| null
+    localsConvention?:
+      | 'camelCase'
+      | 'camelCaseOnly'
+      | 'dashes'
+      | 'dashesOnly'
+      | null
   }
   ```
 

--- a/config/index.md
+++ b/config/index.md
@@ -236,9 +236,9 @@ export default defineConfig(async ({ command, mode }) => {
       | ((name: string, filename: string, css: string) => string)
     hashPrefix?: string
     /**
-     * デフォルト: 'camelCaseOnly'
+     * デフォルト: null
      */
-    localsConvention?: 'camelCase' | 'camelCaseOnly' | 'dashes' | 'dashesOnly'
+    localsConvention?: 'camelCase' | 'camelCaseOnly' | 'dashes' | 'dashesOnly'| null
   }
   ```
 


### PR DESCRIPTION
resolves #222 resolves #224

vitejs/vite@8a8b296 と vitejs/vite@c344865 の取り込みです
（`api-plugin.md` はすでに空行削除されていたので差分なし）