### PR TITLE
docs: fix gitlab pages deploy syntax

### DIFF
--- a/guide/static-deploy.md
+++ b/guide/static-deploy.md
@@ -159,7 +159,7 @@ $ npm run preview
        paths:
          - public
      rules:
-       - $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+       - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
    ```
 
 ## Netlify


### PR DESCRIPTION
resolves #226 

vitejs/vite@4bc9483 の取り込みです