### PR TITLE
コミットするファイルだけを lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "pre-commit": "lint-staged"
   },
   "lint-staged": {
-    "*.md": "npm run lint"
+    "*.md": "textlint --format pretty-error"
   }
 }


### PR DESCRIPTION
コミット時、全ての md ファイルを textlint でチェックしていて時間がかかるので、ステージングファイルのみ lint するよう変更しました