### PR TITLE
docs(lib-mode): add a caveat to the build.minify docs for 'es' format

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -771,6 +771,8 @@ export default defineConfig({
 
   ミニファイを無効にするには `false` を設定するか、使用するミニファイツールを指定します。デフォルトは [Esbuild](https://github.com/evanw/esbuild) で、これは terser に比べて 20～40 倍速く、圧縮率は 1～2％だけ低下します。[ベンチマーク](https://github.com/privatenumber/minification-benchmarks)
 
+  ライブラリモードで `'es'` フォーマットを使用する場合、`build.minify` オプションは使えないので注意してください。
+
 ### build.terserOptions
 
 - **型:** `TerserOptions`


### PR DESCRIPTION
resolves #255

vitejs/vite@0f393a1 の取り込みと翻訳です。