### PR TITLE
docs(config): added an example about proxying websockets

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -474,6 +474,11 @@ export default defineConfig(async ({ command, mode }) => {
           configure: (proxy, options) => {
             // プロキシは 'http-proxy' のインスタンスになります
           },
+        },
+        // Web ソケット か socket.io をプロキシ化
+        '/socket.io': {
+          target: 'ws://localhost:3000',
+          ws: true
         }
       }
     }


### PR DESCRIPTION
resolves #280

vitejs/vite@678e0f2 の取り込みと翻訳です