### PR TITLE
refactor: avoid splitting vendor chunk by default

### DIFF
--- a/guide/build.md
+++ b/guide/build.md
@@ -43,6 +43,20 @@ module.exports = defineConfig({
 
 例えば、ビルド時にのみ適用されるプラグインを使って複数の Rollup 出力を指定することができます。
 
+## チャンク戦略
+
+チャンクの分割方法は `build.rollupOptions.manualChunks` で設定できます（[Rollup ドキュメント](https://rollupjs.org/guide/en/#outputmanualchunks)参照）。Vite 2.7 まではデフォルトのチャンク戦略は `index` と `vendor` にチャンクを分割していました。これは SPA にはよい戦略の場合もありますが、すべての Vite ターゲットのユースケースに対して一般的な解決策を提供するのは困難です。Vite 2.8 からは、`manualChunks` はデフォルトでは変更されなくなりました。設定ファイルに `splitVendorChunkPlugin` を追加すれば、vender を分割するチャンク戦略を引き続き使用できます:
+
+```js
+// vite.config.js
+import { splitVendorChunkPlugin } from 'vite'
+module.exports = defineConfig({
+  plugins: [splitVendorChunkPlugin()]
+})
+```
+
+カスタムロジックによる合成が必要な場合に備えて、この戦略は `splitVendorChunk({ cache: SplitVendorChunkCache })` ファクトリとしても提供されます。`cache.reset()` はこの場合、ビルドウォッチモードが正しく動作するように `buildStart` で呼び出す必要があります。
+
 ## ファイル変更時のリビルド
 
 `vite build --watch` で rollup のウォッチャを有効にすることができます。 また、`build.watch` を介して基礎となる [`WatcherOptions`](https://rollupjs.org/guide/en/#watch-options) を直接調整することもできます:

--- a/guide/build.md
+++ b/guide/build.md
@@ -45,7 +45,7 @@ module.exports = defineConfig({
 
 ## チャンク戦略
 
-チャンクの分割方法は `build.rollupOptions.manualChunks` で設定できます（[Rollup ドキュメント](https://rollupjs.org/guide/en/#outputmanualchunks)参照）。Vite 2.7 まではデフォルトのチャンク戦略は `index` と `vendor` にチャンクを分割していました。これは SPA にはよい戦略の場合もありますが、すべての Vite ターゲットのユースケースに対して一般的な解決策を提供するのは困難です。Vite 2.8 からは、`manualChunks` はデフォルトでは変更されなくなりました。設定ファイルに `splitVendorChunkPlugin` を追加すれば、vender を分割するチャンク戦略を引き続き使用できます:
+チャンクの分割方法は `build.rollupOptions.output.manualChunks` で設定できます（[Rollup ドキュメント](https://rollupjs.org/guide/en/#outputmanualchunks)参照）。Vite 2.8 まではデフォルトのチャンク戦略は `index` と `vendor` にチャンクを分割していました。これは SPA にはよい戦略の場合もありますが、すべての Vite ターゲットのユースケースに対して一般的な解決策を提供するのは困難です。Vite 2.9 からは、`manualChunks` はデフォルトでは変更されなくなりました。設定ファイルに `splitVendorChunkPlugin` を追加すれば、vender を分割するチャンク戦略を引き続き使用できます:
 
 ```js
 // vite.config.js

--- a/guide/build.md
+++ b/guide/build.md
@@ -55,7 +55,7 @@ module.exports = defineConfig({
 })
 ```
 
-カスタムロジックによる合成が必要な場合に備えて、この戦略は `splitVendorChunk({ cache: SplitVendorChunkCache })` ファクトリとしても提供されます。`cache.reset()` はこの場合、ビルドウォッチモードが正しく動作するように `buildStart` で呼び出す必要があります。
+カスタムロジックによる合成が必要な場合に備えて、この戦略は `splitVendorChunk({ cache: SplitVendorChunkCache })` ファクトリとしても提供されます。この場合、ビルドウォッチモードが正しく動作するように、`cache.reset()` は `buildStart` で呼び出す必要があります。
 
 ## ファイル変更時のリビルド
 


### PR DESCRIPTION
resolve #325 resolve #335

https://github.com/vitejs/vite/commit/849e8456e1f7609040030c87cdc51e2fc76235b7, https://github.com/vitejs/vite/commit/7dcf370d0f27ef7d5073006fcd943ab9083cabe1 の取り込みと翻訳です