### PR TITLE
chore: fix term cases

### DIFF
--- a/blog/announcing-vite2.md
+++ b/blog/announcing-vite2.md
@@ -34,7 +34,7 @@ The [programmatic API](https://vitejs.dev/guide/api-javascript.html) has also be
 
 ### esbuild Powered Dep Pre-Bundling
 
-Since Vite is a native ESM dev server, it pre-bundles dependencies to reduce the number browser requests and handle CommonJS to ESM conversion. Previously Vite did this using Rollup, and in 2.0 it now uses `esbuild` which results in 10-100x faster dependency pre-bundling. As a reference, cold-booting a test app with heavy dependencies like React Material UI previously took 28 seconds on an M1-powered Macbook Pro and now takes ~1.5 seconds. Expect similar improvements if you are switching from a traditional bundler based setup.
+Since Vite is a native ESM dev server, it pre-bundles dependencies to reduce the number browser requests and handle CommonJS to ESM conversion. Previously Vite did this using Rollup, and in 2.0 it now uses `esbuild` which results in 10-100x faster dependency pre-bundling. As a reference, cold-booting a test app with heavy dependencies like React Material UI previously took 28 seconds on an M1-powered MacBook Pro and now takes ~1.5 seconds. Expect similar improvements if you are switching from a traditional bundler based setup.
 
 ### First-class CSS Support
 

--- a/config/index.md
+++ b/config/index.md
@@ -322,7 +322,7 @@ export default defineConfig(async ({ command, mode }) => {
 
 - **型:** `ESBuildOptions | false`
 
-  `ESBuildOptions` は [ESbuild 自身の変換オプション](https://esbuild.github.io/api/#transform-api)を拡張します。最も一般的な使用例は、JSX のカスタマイズです:
+  `ESBuildOptions` は [esbuild 自身の変換オプション](https://esbuild.github.io/api/#transform-api)を拡張します。最も一般的な使用例は、JSX のカスタマイズです:
 
   ```js
   export default defineConfig({
@@ -333,9 +333,9 @@ export default defineConfig(async ({ command, mode }) => {
   })
   ```
 
-  デフォルトでは ESBuild は `ts`, `jsx`, `tsx` ファイルに適用されます。`esbuild.include` と `esbuild.exclude` でカスタマイズでき、どちらも `string | RegExp | (string | RegExp)[]` の型を想定しています。
+  デフォルトでは esbuild は `ts`, `jsx`, `tsx` ファイルに適用されます。`esbuild.include` と `esbuild.exclude` でカスタマイズでき、どちらも `string | RegExp | (string | RegExp)[]` の型を想定しています。
 
-  また、`esbuild.jsxInject` を使用すると、ESBuild で変換されたすべてのファイルに対して JSX ヘルパの import を自動的に注入できます:
+  また、`esbuild.jsxInject` を使用すると、esbuild で変換されたすべてのファイルに対して JSX ヘルパの import を自動的に注入できます:
 
   ```js
   export default defineConfig({
@@ -345,7 +345,7 @@ export default defineConfig(async ({ command, mode }) => {
   })
   ```
 
-  ESbuild の変換を無効にするには `false` を設定します。
+  esbuild の変換を無効にするには `false` を設定します。
 
 ### assetsInclude
 
@@ -804,7 +804,7 @@ export default defineConfig({
 - **型:** `boolean | 'terser' | 'esbuild'`
 - **デフォルト:** `'esbuild'`
 
-  ミニファイを無効にするには `false` を設定するか、使用するミニファイツールを指定します。デフォルトは [Esbuild](https://github.com/evanw/esbuild) で、これは terser に比べて 20～40 倍速く、圧縮率は 1～2％だけ低下します。[ベンチマーク](https://github.com/privatenumber/minification-benchmarks)
+  ミニファイを無効にするには `false` を設定するか、使用するミニファイツールを指定します。デフォルトは [esbuild](https://github.com/evanw/esbuild) で、これは terser に比べて 20～40 倍速く、圧縮率は 1～2％だけ低下します。[ベンチマーク](https://github.com/privatenumber/minification-benchmarks)
 
   ライブラリモードで `'es'` フォーマットを使用する場合、`build.minify` オプションは使えないので注意してください。
 

--- a/guide/api-javascript.md
+++ b/guide/api-javascript.md
@@ -1,6 +1,6 @@
 # JavaScript API
 
-Vite の JavaScript API は完全に型付けされているので、自動補完とバリデーションを活用するために VSCode の JS 型チェックを有効にするか、TypeScript を使用することをおすすめします。
+Vite の JavaScript API は完全に型付けされているので、自動補完とバリデーションを活用するために VS Code の JS 型チェックを有効にするか、TypeScript を使用することをおすすめします。
 
 ## `createServer`
 

--- a/guide/static-deploy.md
+++ b/guide/static-deploy.md
@@ -299,7 +299,7 @@ Vercel CLI
 
 ### Vercel for Git
 
-1. コードを Git リポジトリ（GitHub, GitLab, BitBucket）にプッシュします。
+1. コードを Git リポジトリ（GitHub, GitLab, Bitbucket）にプッシュします。
 2. Vercel に [Vite プロジェクトをインポート](https://vercel.com/new)します。
 3. Vercel はあなたが Vite を使用していることを検出し、あなたのデプロイメントのための正しい設定を有効にします。
 4. アプリケーションがデプロイされます！（例: [vite-vue-template.vercel.app](https://vite-vue-template.vercel.app/)）


### PR DESCRIPTION
resolve #374

vitejs/vite@c296130 の反映です

- `CONTRIBUTING.md` は「日本語翻訳ガイド」に変わっているので修正なし
- `why.md` は（おそらく）翻訳時に対応済みなので修正なし