### PR TITLE
docs: import.meta.url is replaced even if ESM

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -28,7 +28,7 @@ vite --config my-config.js
 ```
 
 ::: tip 注意
-Vite は **CommonJS** と**TypeScript** の設定ファイルの `__filename`, `__dirname`, `import.meta.url` を置換することに注意してください。これらを変数名として使用すると、エラーになります:
+Vite は設定ファイルとその依存関係内の `__filename`, `__dirname`, `import.meta.url` を置換することに注意してください。これらを変数名として使用すると、エラーになります:
 
 ```js
 const __filename = "value"


### PR DESCRIPTION
resolve #395 
https://github.com/vitejs/vite/commit/6198911faeee3b915fc0d4ff24fbb918f3e1d558 の反映です
