### PR TITLE
refactor: remove deprecated api for 3.0

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -336,7 +336,7 @@ export default defineConfig(({ command, mode }) => {
 
   `true` に設定すると、インポートされた JSON は `export default JSON.parse("...")` に変換されます。これは特に JSON ファイルが大きい場合、オブジェクトリテラルよりも大幅にパフォーマンスが向上します。
 
-  有効にすると、名前付きインポートは無効になります。 
+  有効にすると、名前付きインポートは無効になります。
 
 ### esbuild
 
@@ -713,7 +713,7 @@ export default defineConfig({
   ```
 
   注意: この Polyfill は[ライブラリモード](/guide/build#ライブラリモード)には **適用されません** 。ネイティブの動的インポートを持たないブラウザをサポートする必要がある場合は、ライブラリでの使用は避けた方が良いでしょう。
-  
+
 ### build.outDir
 
 - **型:** `string`
@@ -987,7 +987,6 @@ export default defineConfig({
 
   - `external` も省略されています。Vite の `optimizeDeps.exclude` オプションを使用してください
   - `plugins` は Vite の依存関係プラグインとマージされます
-  - `keepNames` は非推奨の `optimizeDeps.keepNames` よりも優先されます
 
 ## SSR オプション
 


### PR DESCRIPTION
resolve #411 
https://github.com/vitejs/vite/commit/b5c370941bb36bdb420433ca16cea9c2402b9810 の反映です。

また、ISSUEで確認させていただいた上、
`conifg/index.md`内にある行末のスペースも削除しています。