### PR TITLE
docs: correct link to Discord

### DIFF
--- a/guide/index.md
+++ b/guide/index.md
@@ -145,4 +145,4 @@ pnpm link --global # このステップでは好きなパッケージマネー�
 
 ## コミュニティ
 
-質問がある場合やサポートが必要な場合は、[Discord](https://discord.gg/4cmKdMfpU5) や [GitHub Discussions](https://github.com/vitejs/vite/discussions) でコミュニティに連絡してください。
+質問がある場合やサポートが必要な場合は、[Discord](https://chat.vitejs.dev) や [GitHub Discussions](https://github.com/vitejs/vite/discussions) でコミュニティに連絡してください。


### PR DESCRIPTION
resolve #438 
https://github.com/vitejs/vite/commit/e23ba3593cf71edf76840b4f57935c575c698793 の反映です。
