### PR TITLE
fix: wasmの訳の修正

### DIFF
--- a/guide/features.md
+++ b/guide/features.md
@@ -435,13 +435,13 @@ const module = await import(`./dir/${file}.js`)
 
 ## WebAssembly
 
-`?init` を使うことでプリコンパイルされた `.wasm` ファイルをインポートできます - デフォルトのエクスポートは、wasm インスタンスの exports オブジェクトの Promise を返す初期化関数になります:
+`?init` を使うことでプリコンパイルされた `.wasm` ファイルをインポートできます - デフォルトのエクスポートは、wasm インスタンスの Promise を返す初期化関数になります:
 
 ```js
 import init from './example.wasm?init'
 
 init().then((instance) => {
-  instance.test()
+  instance.exports.test()
 })
 ```
 


### PR DESCRIPTION
#463 の一部の修正です

元コミット: https://github.com/vitejs/vite/commit/75c3bf65694bc89b395e03dabb81721871d24a9c
