### PR TITLE
refactor!: make terser an optional dependency

### DIFF
--- a/config/build-options.md
+++ b/config/build-options.md
@@ -145,7 +145,13 @@ SSR 向けのビルドを生成します。この値は、SSR エントリを直
 
 ミニファイを無効にするには `false` を設定するか、使用するミニファイツールを指定します。デフォルトは [esbuild](https://github.com/evanw/esbuild) で、これは terser に比べて 20～40 倍速く、圧縮率は 1～2％だけ低下します。[ベンチマーク](https://github.com/privatenumber/minification-benchmarks)
 
-  ライブラリモードで `'es'` フォーマットを使用する場合、`build.minify` オプションは使えないので注意してください。
+ライブラリモードで `'es'` フォーマットを使用する場合、`build.minify` オプションは使えないので注意してください。
+
+terser は `'terser'` を設定したときににインストールされます。
+
+```sh
+npm add -D terser
+```
 
 ## build.terserOptions
 


### PR DESCRIPTION
resolve #488 
https://github.com/vitejs/vite/commit/164f528838f3a146c82d68992d38316b9214f9b8 の反映です。

本家の方にはpnpm-lock.yamlも変更があったのですが、
lockファイル内の記述的にplaygroundを動かすために必要と思われ、翻訳サイトにはなくて問題ないと判断し、ライブラリの変更は特にしてません。