### PR TITLE
feat: avoid scanner during build and only optimize CJS in SSR, chore: update vitepress to 1.0.0-alpha.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "textlint": "^12.0.2",
     "textlint-filter-rule-allowlist": "^4.0.0",
     "textlint-rule-preset-vuejs-jp": "git+https://github.com/vuejs-jp/textlint-rule-preset-vuejs-jp.git",
-    "vitepress": "^1.0.0-alpha.2",
+    "vitepress": "^1.0.0-alpha.4",
     "yorkie": "^2.0.0"
   },
   "gitHooks": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,5 +6,10 @@ export default defineConfig({
   },
   legacy: {
     buildSsrCjsExternalHeuristics: true
+  },
+  optimizeDeps: {
+    // vitepress is aliased with replacement `join(DIST_CLIENT_PATH, '/index')`
+    // This needs to be excluded from optimization
+    exclude: ['vitepress']
   }
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3050,10 +3050,10 @@ vite@^2.9.7:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vitepress@^1.0.0-alpha.2:
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/vitepress/-/vitepress-1.0.0-alpha.2.tgz#aa25845b8672efe0f0e22ff77c4b7ef09f1831a9"
-  integrity sha512-twSsmx2DI/3XgZZ8KLyRAH8RgK2Zj4kJx/kwhZhimwndYqQDrtcIaAcuV+P3FKukZ+cYtm9yt9qohz631jKx4A==
+vitepress@^1.0.0-alpha.4:
+  version "1.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/vitepress/-/vitepress-1.0.0-alpha.4.tgz#2d9929e2cade3d98f57f61848c01968fb386cee0"
+  integrity sha512-bOAA4KW6vYGlkbcrPLZLTKWTgXVroObU+o9xj9EENyEl6yg26WWvfN7DGA4BftjdM5O8nR93Z5khPQ3W/tFE7Q==
   dependencies:
     "@docsearch/css" "^3.0.0"
     "@docsearch/js" "^3.0.0"


### PR DESCRIPTION
resolve #557
https://github.com/vitejs/vite/commit/339d9e394620c843c9c0c9c8afc4d77e27879620 の反映です

また、vitepressのバージョンをviteに合わせて1.0.0-alpha.4にしています
https://github.com/vitejs/vite/blob/339d9e394620c843c9c0c9c8afc4d77e27879620/package.json#L93
https://github.com/vitejs/vite/blob/339d9e394620c843c9c0c9c8afc4d77e27879620/pnpm-lock.yaml#L8468
