### PR TITLE
fix: SSRガイドのconfigureServerのリンク

### DIFF
--- a/guide/ssr.md
+++ b/guide/ssr.md
@@ -264,7 +264,7 @@ SSR ビルドのデフォルトターゲットは Node 環境ですが、Web Wor
 
 ## Vite CLI
 
-コマンドラインコマンドの `$ vite dev` と `$ vite preview` は SSR アプリでも使用することができます。開発サーバには `configureServer`](/guide/api-plugin#configureserver) 、プレビューサーバには [`configurePreviewServer`](/guide/api-plugin#configurepreviewserver) で SSR ミドルウェアを追加できます。
+コマンドラインコマンドの `$ vite dev` と `$ vite preview` は SSR アプリでも使用することができます。開発サーバには [`configureServer`](/guide/api-plugin#configureserver) 、プレビューサーバには [`configurePreviewServer`](/guide/api-plugin#configurepreviewserver) で SSR ミドルウェアを追加できます。
 
 :::tip 注意
 ポストフックを使用して、SSR ミドルウェアが Vite のミドルウェアの後に実行されるようにしてください。


### PR DESCRIPTION
リンクが壊れていたので修正しました
https://github.com/vitejs/vite/commit/e5ddfa824656fe34d8bda8a440505be7adf67a1e の地点でも壊れていなかったので、おそらく原文は壊れていません