### PR TITLE
"Edit page" GitHub link points to incorrect path

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -77,7 +77,7 @@ export default defineConfig({
     logo: '/logo.svg',
 
     editLink: {
-      pattern: 'https://github.com/vitejs/vite/edit/main/docs/:path',
+      pattern: 'https://github.com/vitejs/docs-ja/edit/main/:path',
       text: 'このページへの変更を提案する'
     },
 


### PR DESCRIPTION
- Source repo should be updated to `vitejs/docs-ja`.
- `vitejs/vite` had all paths nested under `docs/` which is not needed here in this new repo. I have removed it.