### PR TITLE
fix: fix typo

### DIFF
--- a/guide/build.md
+++ b/guide/build.md
@@ -48,7 +48,7 @@ export default defineConfig({
 
 ## チャンク戦略
 
-チャンクの分割方法は `build.rollupOptions.output.manualChunks` で設定できます（[Rollup ドキュメント](https://rollupjs.org/guide/en/#outputmanualchunks)参照）。Vite 2.8 まではデフォルトのチャンク戦略は `index` と `vendor` にチャンクを分割していました。これは SPA にはよい戦略の場合もありますが、すべての Vite ターゲットのユースケースに対して一般的な解決策を提供するのは困難です。Vite 2.9 からは、`manualChunks` はデフォルトでは変更されなくなりました。設定ファイルに `splitVendorChunkPlugin` を追加すれば、vender を分割するチャンク戦略を引き続き使用できます:
+チャンクの分割方法は `build.rollupOptions.output.manualChunks` で設定できます（[Rollup ドキュメント](https://rollupjs.org/guide/en/#outputmanualchunks)参照）。Vite 2.8 まではデフォルトのチャンク戦略は `index` と `vendor` にチャンクを分割していました。これは SPA にはよい戦略の場合もありますが、すべての Vite ターゲットのユースケースに対して一般的な解決策を提供するのは困難です。Vite 2.9 からは、`manualChunks` はデフォルトでは変更されなくなりました。設定ファイルに `splitVendorChunkPlugin` を追加すれば、vendor を分割するチャンク戦略を引き続き使用できます:
 
 ```js
 // vite.config.js


### PR DESCRIPTION
軽微な修正のため、該当 issue 無し
resolve #000 ←（`000` の部分を実際の issue 番号に書き換えてください）

ガイド > 本番環境用のビルド > チャンク戦略

で、`vendor` という単語の表記ゆれを見つけたので、修正の PR となります。


よろしくお願いします。