### PR TITLE
feat!: support safari14 by default for wider ES2020 compatibility

### DIFF
--- a/guide/build.md
+++ b/guide/build.md
@@ -8,7 +8,7 @@
 
 - Chrome >=87
 - Firefox >=78
-- Safari >=13
+- Safari >=14
 - Edge >=88
 
 [`build.target` 設定オプション](/config/build-options.md#build-target) を介してカスタムターゲットを指定することができます。最も低いターゲットは `es2015` です。


### PR DESCRIPTION
resolve #742

vitejs/vite@3cc65d7 の反映です