### PR TITLE
docs: build.assetsDir only used in non lib mode

### DIFF
--- a/config/build-options.md
+++ b/config/build-options.md
@@ -78,7 +78,7 @@ modulePreload: {
 - **型:** `string`
 - **デフォルト:** `assets`
 
-生成されたアセットをネストするディレクトリを指定します（`build.outDir` からの相対パス）。
+生成されたアセットをネストするディレクトリを指定します（`build.outDir` からの相対パス。[ライブラリモード](/guide/build#library-mode)では使用しません）。
 
 ## build.assetsInlineLimit
 


### PR DESCRIPTION
resolve #879

vitejs/vite@3551f75 の反映です
