### PR TITLE
chore: add `português` to locales in `.vitepress/config.ts` (#918)

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -91,6 +91,7 @@ export default defineConfig({
     en: { label: 'English', link: 'https://vitejs.dev' },
     zh: { label: '简体中文', link: 'https://cn.vitejs.dev' },
     es: { label: 'Español', link: 'https://es.vitejs.dev' },
+    pt: { label: 'Português', link: 'https://pt.vitejs.dev' },
   },
 
   vue: {


### PR DESCRIPTION
resolves #918
Cherry picked from https://github.com/vitejs/vite/commit/4a42c9093ec9d6ec8782bde3a2aafebc5f9f1d08