### PR TITLE
fix:環境変数の項目のcode blockの修正

### DIFF
--- a/guide/migration.md
+++ b/guide/migration.md
@@ -40,7 +40,7 @@ import stuff from './global.css?inline'
 
 ### 環境変数
 
-Vite では `dotenv` 16 と `dotenv-expand` 9 を使うようになりました（以前は `dotenv` 14 と `dotenv-expand` 5）。`#` や `` `` を含む値がある場合は、それらを引用符で囲む必要があります。
+Vite では `dotenv` 16 と `dotenv-expand` 9 を使うようになりました（以前は `dotenv` 14 と `dotenv-expand` 5）。`#` や `` ` `` を含む値がある場合は、それらを引用符で囲む必要があります。
 
 ```diff
 -VITE_APP=ab#cd`ef


### PR DESCRIPTION
軽微なtypoなのでissueなしです。

[環境変数](https://ja.vitejs.dev/guide/migration.html#%E7%92%B0%E5%A2%83%E5%A4%89%E6%95%B0)の項目で

> `` ` `` を含む値

の `` ` ``が表示されていなかったのを修正しています

![image](https://user-images.githubusercontent.com/46278200/235461893-2ecd5378-69d8-4247-a073-7e786ab53209.png)

