### PR TITLE
docs: update Vue 2 plugins

### DIFF
--- a/guide/api-plugin.md
+++ b/guide/api-plugin.md
@@ -159,7 +159,9 @@ Vite (および Rollup) の仮想モジュールは慣例により、ユーザ�
 - [`load`](https://rollupjs.org/plugin-development/#load)
 - [`transform`](https://rollupjs.org/plugin-development/#transform)
 
-また、Vite 固有のプロパティを追加した拡張 `options` パラメータを持ちます。詳しくは [SSR ドキュメント](/guide/ssr#ssr-specific-plugin-logic)に書かれています。
+また、これらのフックは Vite 固有のプロパティを追加した拡張 `options` パラメータを持ちます。詳しくは [SSR ドキュメント](/guide/ssr#ssr-specific-plugin-logic)に書かれています。
+
+Vite によるバンドルされていない開発サーバパターンにより、実際のインポータを導き出すことができない場合があるため、一部の `resolveId` 呼び出しの `importer` 値はルートにある一般的な `index.html` の絶対パスであるかもしれません。Vite の resolve pipeline 内で処理されるインポートについては、インポートの解析段階でインポータを追跡して、正しい `importer` 値を提供することができます。
 
 以下のフックはサーバが閉じられる時に呼び出されます:
 

--- a/guide/features.md
+++ b/guide/features.md
@@ -138,8 +138,8 @@ Vite は Vue に対して最高のサポートをします:
 
 - Vue 3 SFC はこちら [@vitejs/plugin-vue](https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue)
 - Vue 3 JSX はこちら [@vitejs/plugin-vue-jsx](https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue-jsx)
-- Vue 2.7 はこちら [@vitejs/plugin-vue2](https://github.com/vitejs/vite-plugin-vue2)
-- Vue &lt;2.7 はこちら [vite-plugin-vue2](https://github.com/underfin/vite-plugin-vue2)
+- Vue 2.7 SFC はこちら [@vitejs/plugin-vue2](https://github.com/vitejs/vite-plugin-vue2)
+- Vue 2.7 JSX はこちら [@vitejs/plugin-vue2-jsx](https://github.com/vitejs/vite-plugin-vue2-jsx)
 
 ## JSX
 

--- a/plugins/index.md
+++ b/plugins/index.md
@@ -18,7 +18,11 @@ Vite は、一般的な Web 開発パターンをすぐに使えるようにサ�
 
 ### [@vitejs/plugin-vue2](https://github.com/vitejs/vite-plugin-vue2)
 
-- Vue 2 の単一ファイルコンポーネントのサポートを提供します。
+- Vue 2.7 の単一ファイルコンポーネントのサポートを提供します。
+
+### [@vitejs/plugin-vue2-jsx](https://github.com/vitejs/vite-plugin-vue2-jsx)
+
+- Vue 2.7 の JSX（[専用の Babel transform ](https://github.com/vuejs/jsx-vue2/)を介して）のサポートを提供します。
 
 ### [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react)
 


### PR DESCRIPTION
resolve #962

mainブランチにすでに #965 はマージされていると認識しているんですが、差分として表示されてしまっています。
原因を調査したのですがわかっておらず、ドラフトでPR出しています。
前回チェック項目が失敗しているのも少し気になっております。