### PR TITLE
docs: add manualChunks object form syntax warning when it is used with the splitVendorChunk plugin

### DIFF
--- a/guide/build.md
+++ b/guide/build.md
@@ -60,6 +60,10 @@ export default defineConfig({
 
 カスタムロジックによる合成が必要な場合に備えて、この戦略は `splitVendorChunk({ cache: SplitVendorChunkCache })` ファクトリとしても提供されます。この場合、ビルドウォッチモードが正しく動作するように、`cache.reset()` は `buildStart` で呼び出す必要があります。
 
+::: warning
+このプラグインを使用する場合は、 `build.rollupOptions.output.manualChunks` を関数形式で使用する必要があります。オブジェクト形式を使用すると、プラグインは何の効果も持ちません。
+:::
+
 ## ファイル変更時のリビルド
 
 `vite build --watch` で rollup のウォッチャを有効にすることができます。 また、`build.watch` を介して基礎となる [`WatcherOptions`](https://rollupjs.org/configuration-options/#watch) を直接調整することもできます:


### PR DESCRIPTION
resolve: https://github.com/vitejs/docs-ja/issues/990

https://github.com/vitejs/vite/commit/17511e03c2d4d3ad8191101d1cf04c4fe5c78e8c の反映です。