### PR TITLE
docs: remove note about firefox not supporting ESM imports in Web Workers

### DIFF
--- a/guide/features.md
+++ b/guide/features.md
@@ -559,7 +559,7 @@ import MyWorker from './worker?worker'
 const worker = new MyWorker()
 ```
 
-ワーカスクリプトは、`importScripts()` の代わりに ESM の `import` ステートメントを使用することもできます。**注意**: 開発中は[ブラウザのネイティブサポート](https://caniuse.com/?search=module%20worker)（現在 Firefox ではサポートされていません）に依存しますが、プロダクションビルドではコンパイルされます。
+ワーカスクリプトは、`importScripts()` の代わりに ESM の `import` ステートメントを使用することもできます。**注意**: 開発中は[ブラウザのネイティブサポート](https://caniuse.com/?search=module%20worker)に依存しますが、プロダクションビルドではコンパイルされます。
 
 デフォルトでは、ワーカスクリプトは本番ビルドで個別のチャンクとして出力されます。ワーカを base64 文字列としてインライン化する場合は、`inline` クエリを追加します:
 


### PR DESCRIPTION
resolves https://github.com/vitejs/docs-ja/issues/1042
https://github.com/vitejs/vite/commit/bbd1ffd2751b2e32eefa24958598c85026acf19a の反映です。