### PR TITLE
docs: use extends instead of spreading default theme (#1090)

### DIFF
--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -1,14 +1,15 @@
 import { h } from 'vue'
-import Theme from 'vitepress/theme'
+import type { Theme } from 'vitepress'
+import DefaultTheme from 'vitepress/theme'
 import './styles/vars.css'
 import HomeSponsors from './components/HomeSponsors.vue'
 import AsideSponsors from './components/AsideSponsors.vue'
 import SvgImage from './components/SvgImage.vue'
 
 export default {
-  ...Theme,
+  extends: DefaultTheme,
   Layout() {
-    return h(Theme.Layout, null, {
+    return h(DefaultTheme.Layout, null, {
       'home-features-after': () => h(HomeSponsors),
       'aside-ads-before': () => h(AsideSponsors),
     })
@@ -16,4 +17,4 @@ export default {
   enhanceApp({ app }) {
     app.component('SvgImage', SvgImage)
   },
-}
+} satisfies Theme


### PR DESCRIPTION
resolves #1090
Cherry picked from https://github.com/vitejs/vite/commit/dc5896cf0b24b2313855a2bbd32e7bf9c33c5c69