### PR TITLE
docs: clarify origin part of `base` is not used in dev

### DIFF
--- a/config/shared-options.md
+++ b/config/shared-options.md
@@ -13,11 +13,12 @@
 
 - **型:** `string`
 - **デフォルト:** `/`
+- **関連:** [`server.origin`](/config/server-options.md#server-origin)
 
 開発環境または本番環境で配信される際のベースとなるパブリックパス。有効な値は次のとおりです:
 
 - 絶対 URL パス名。例 `/foo/`
-- 完全な URL。例 `https://foo.com/`
+- 完全な URL。例 `https://foo.com/`（オリジン部分は開発には使用されません）
 - 空文字列または `./`（埋め込みデプロイ用）
 
 詳細は [Public Base Path](/guide/build#public-base-path) を参照してください。


### PR DESCRIPTION
resolve #1168

vitejs/vite@1e9bf06 の反映です