### PR TITLE
fix: pass `customLogger` to `loadConfigFromFile` (fix #15824)

### DIFF
--- a/guide/api-javascript.md
+++ b/guide/api-javascript.md
@@ -393,6 +393,7 @@ async function loadConfigFromFile(
   configFile?: string,
   configRoot: string = process.cwd(),
   logLevel?: LogLevel,
+  customLogger?: Logger,
 ): Promise<{
   path: string
   config: UserConfig


### PR DESCRIPTION
resolve #1303

https://github.com/vitejs/vite/commit/55a3427ef8ff491de913f304cb404551e33265bd の反映です。

行数がずれているので、#1306 のマージを先にお願いします。