### PR TITLE
docs: remove `vue` from the example when `skipLibCheck` needs to be e…

### DIFF
--- a/guide/features.md
+++ b/guide/features.md
@@ -65,7 +65,7 @@ export type { T }
 
 隔離されたトランスパイルで動作しない機能を TS が警告するように、`tsconfig.json` の `compilerOptions` で `"isolatedModules": true` を設定する必要があります。
 
-しかし、一部のライブラリー (例えば [`vue`](https://github.com/vuejs/core/issues/1228)) は `"isolatedModules": true` でうまく動作しないことがあります。`"skipLibCheck": true` を使用すると、アップストリームで修正されるまで一時的にエラーを抑制することができます。
+もし依存関係が `"isolatedModules": true` でうまく動作しない場合は、`"skipLibCheck": true` を使用すると、アップストリームで修正されるまで一時的にエラーを抑制できます。
 
 #### `useDefineForClassFields`
 


### PR DESCRIPTION
resolve #1365

https://github.com/vitejs/vite/commit/1574f3565d28ec15a3a5708d2214b75b42d8a44f の反映です。
