### PR TITLE
docs: add Mastodon to “resources” in docs navigation (#1391)

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -156,6 +156,10 @@ export default defineConfig({
           {
             items: [
               {
+                text: 'Mastodon',
+                link: 'https://elk.zone/m.webtoo.ls/@vite',
+              },
+              {
                 text: 'Twitter',
                 link: 'https://twitter.com/vite_js',
               },


### PR DESCRIPTION
resolves #1391
Cherry picked from https://github.com/vitejs/vite/commit/60367eee87e0764d7137320827f3975d6a45bd2c