### PR TITLE
`lint.yml` で使われている Actions のバージョンを更新

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,11 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: pnpm/action-setup@v2
-      with:
-        version: 8
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: pnpm/action-setup@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: 18
         cache: 'pnpm'


### PR DESCRIPTION
3つのActionsでそれぞれ新しいメジャーバージョンがリリースされていたので更新しました。