### PR TITLE
"Type signature" の翻訳ミスを修正

### DIFF
--- a/guide/api-javascript.md
+++ b/guide/api-javascript.md
@@ -429,7 +429,7 @@ esbuild で Vite の設定ファイルを手動で読み込みます。
 
 - **実験的機能:** [フィードバックをしてください](https://github.com/vitejs/vite/discussions/13815)
 
-**型:**
+**型シグネチャー:**
 
 ```ts
 async function preprocessCSS(


### PR DESCRIPTION
前回の翻訳 (https://github.com/vitejs/docs-ja/pull/1449) で「型シグネチャー」とすべきところを「型」と訳してしまっていたので、その修正です。