### PR TITLE
docs: clarify when `transformIndexHtml` hook runs or not

### DIFF
--- a/guide/api-plugin.md
+++ b/guide/api-plugin.md
@@ -399,6 +399,10 @@ Vite プラグインは Vite 特有の目的を果たすフックを提供する
   }
   ```
 
+::: warning 注意
+エントリーファイルのカスタム処理があるフレームワークを使用している場合、このフックは呼ばれません（たとえば、[SvelteKit](https://github.com/sveltejs/kit/discussions/8269#discussioncomment-4509145)）。
+:::
+
 ### `handleHotUpdate`
 
 - **型:** `(ctx: HmrContext) => Array<ModuleNode> | void | Promise<Array<ModuleNode> | void>`


### PR DESCRIPTION
resolve #1501
resolve #1505

https://github.com/vitejs/vite/commit/a7f98278a40e284b6ae638d42b3a34d95df7eb41 と https://github.com/vitejs/vite/commit/11b12cf284232b56991084327df32daaf603e488 の反映です。
