### PR TITLE
chore(deps)!: migrate `fast-glob` to `tinyglobby`

### DIFF
--- a/config/dep-optimization-options.md
+++ b/config/dep-optimization-options.md
@@ -8,7 +8,7 @@
 
 デフォルトでは、Vite はすべての `.html` ファイルをクロールして、事前にバンドルする必要のある依存関係を検出します（`node_modules`, `build.outDir`, `__tests__` および `coverage` は無視します）。`build.rollupOptions.input` が指定されている場合、Vite は代わりにそれらのエントリーポイントをクロールします。
 
-これらのいずれもニーズに合わない場合、このオプションを使ってカスタムエントリーを指定することができます。値は Vite プロジェクトルートからの相対的な [fast-glob パターン](https://github.com/mrmlnc/fast-glob#basic-syntax) か、パターンの配列でなければいけません。これによりデフォルトのエントリーの推論が上書きされます。`optimizeDeps.entries` が明示的に定義されている場合、デフォルトでは `node_modules` と `build.outDir` フォルダーのみが無視されます。他のフォルダーを無視したい場合は、最初の `!` でマークした無視パターンをエントリーリストの一部として使用できます。`node_modules` と `build.outDir` を無視したくない場合は、代わりに（fast-glob パターンを使用せずに）リテラル文字列を使用してパスを指定できます。
+これらのいずれもニーズに合わない場合、このオプションを使ってカスタムエントリーを指定することができます。値は Vite プロジェクトルートからの相対的な [`tinyglobby` パターン](https://github.com/SuperchupuDev/tinyglobby) か、パターンの配列でなければいけません。これによりデフォルトのエントリーの推論が上書きされます。`optimizeDeps.entries` が明示的に定義されている場合、デフォルトでは `node_modules` と `build.outDir` フォルダーのみが無視されます。他のフォルダーを無視したい場合は、最初の `!` でマークした無視パターンをエントリーリストの一部として使用できます。`node_modules` と `build.outDir` を無視したくない場合は、代わりに（`tinyglobby` パターンを使用せずに）リテラル文字列を使用してパスを指定できます。
 
 ## optimizeDeps.exclude
 

--- a/config/server-options.md
+++ b/config/server-options.md
@@ -184,7 +184,7 @@ Direct websocket connection fallback. Check out https://vite.dev/config/server-o
 
 変換するファイルをウォームアップし、結果を事前にキャッシュします。これにより、サーバー起動時の初期ページ読み込みが改善され、変換ウォーターフォールを防げます。
 
-`clientFiles` はクライアントのみで使用されるファイルであり、`ssrFiles` は SSR のみで使用されるファイルです。これらは `root` を基準としたファイルパスや [`fast-glob`](https://github.com/mrmlnc/fast-glob) パターンの配列を受け入れます。
+`clientFiles` はクライアントのみで使用されるファイルであり、`ssrFiles` は SSR のみで使用されるファイルです。これらは `root` を基準としたファイルパスや [`tinyglobby`](https://github.com/SuperchupuDev/tinyglobby) パターンの配列を受け入れます。
 
 起動時に Vite 開発サーバーに負荷がかからないように、頻繁に使用するファイルのみを追加するようにしてください。
 

--- a/guide/features.md
+++ b/guide/features.md
@@ -542,7 +542,7 @@ const modules = import.meta.glob('./dir/*.js', {
 
 - これは Vite のみの機能で、Web または ES の標準ではありません。
 - Glob パターンはインポート指定子のように扱われます。相対パス（`./` で始まる）か絶対パス（`/` で始まり、プロジェクトルートに対して相対的に解決される）、またはエイリアスのパス（[`resolve.alias` オプション](/config/shared-options.md#resolve-alias) 参照）のいずれかでなければなりません。
-- Glob のマッチングは [`tinyglob`](https://github.com/SuperchupuDev/tinyglobby) を介して行われます。
+- Glob のマッチングは [`tinyglobby`](https://github.com/SuperchupuDev/tinyglobby) を介して行われます。
 - また、`import.meta.glob` の引数はすべて**リテラル構文として渡さなければならない**ことに注意が必要です。変数や式は使えません。
 
 ## Dynamic Import

--- a/guide/features.md
+++ b/guide/features.md
@@ -542,7 +542,7 @@ const modules = import.meta.glob('./dir/*.js', {
 
 - これは Vite のみの機能で、Web または ES の標準ではありません。
 - Glob パターンはインポート指定子のように扱われます。相対パス（`./` で始まる）か絶対パス（`/` で始まり、プロジェクトルートに対して相対的に解決される）、またはエイリアスのパス（[`resolve.alias` オプション](/config/shared-options.md#resolve-alias) 参照）のいずれかでなければなりません。
-- Glob のマッチングは [`fast-glob`](https://github.com/mrmlnc/fast-glob) を介して行われます。[サポートされている Glob パターン](https://github.com/mrmlnc/fast-glob#pattern-syntax)については、ドキュメントを確認してください。
+- Glob のマッチングは [`tinyglob`](https://github.com/SuperchupuDev/tinyglobby) を介して行われます。
 - また、`import.meta.glob` の引数はすべて**リテラル構文として渡さなければならない**ことに注意が必要です。変数や式は使えません。
 
 ## Dynamic Import


### PR DESCRIPTION
resolve #1615

https://github.com/vitejs/vite/commit/6f74a3a1b2469a24a86743d16267b0cc3653bc4a の反映です。
