### PR TITLE
リンク先を日本語版のページに変更

### DIFF
--- a/config/server-options.md
+++ b/config/server-options.md
@@ -38,7 +38,7 @@ export default defineConfig({
 ::: tip LAN から WSL2 上のサーバーにアクセスする
 
 WSL2 上で Vite を動作させる場合、LAN からサーバーにアクセスするために `host: true` を設定するだけでは不十分です。
-詳しくは [WSL のドキュメント](https://learn.microsoft.com/en-us/windows/wsl/networking#accessing-a-wsl-2-distribution-from-your-local-area-network-lan)をご覧ください。
+詳しくは [WSL のドキュメント](https://learn.microsoft.com/ja-jp/windows/wsl/networking#accessing-a-wsl-2-distribution-from-your-local-area-network-lan)をご覧ください。
 
 :::
 

--- a/guide/assets.md
+++ b/guide/assets.md
@@ -113,7 +113,7 @@ import InlineWorker from './shader.js?worker&inline'
 
 ## new URL(url, import.meta.url)
 
-[import.meta.url](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import.meta) は現在のモジュールの URL を公開するネイティブ ESM の機能です。ネイティブの [URL コンストラクター](https://developer.mozilla.org/en-US/docs/Web/API/URL)と組み合わせることで、JavaScript モジュールからの相対パスを使用して静的アセットの完全に解決された URL を取得できます:
+[import.meta.url](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Statements/import.meta) は現在のモジュールの URL を公開するネイティブ ESM の機能です。ネイティブの [URL コンストラクター](https://developer.mozilla.org/ja/docs/Web/API/URL)と組み合わせることで、JavaScript モジュールからの相対パスを使用して静的アセットの完全に解決された URL を取得できます:
 
 ```js
 const imgUrl = new URL('./img.png', import.meta.url).href

--- a/guide/why.md
+++ b/guide/why.md
@@ -22,7 +22,7 @@ Vite はまず最初にアプリケーションのモジュールを 2 つのカ
 
 - **ソースコード**には変換を必要とするプレーンな JavaScript ではないものが含まれることがよくあり、頻繁に編集されます（例: JSX、CSS や Vue/Svelte コンポーネント）。また、全てのソースコードを同時に読み込む必要はありません（例: ルーティングによるコード分割）。
 
-  Vite は、[ネイティブ ESM](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) を行使してソースコードを提供します。ブラウザーは、実質的にバンドラーの仕事の一部を引き受けます: Vite はブラウザーのリクエストに応じて、ソースコードを変換し提供するのみになります。条件で囲われている動的インポートのコードは、現在の画面で使われる場合のみ処理されます。
+  Vite は、[ネイティブ ESM](https://developer.mozilla.org/ja/docs/Web/JavaScript/Guide/Modules) を行使してソースコードを提供します。ブラウザーは、実質的にバンドラーの仕事の一部を引き受けます: Vite はブラウザーのリクエストに応じて、ソースコードを変換し提供するのみになります。条件で囲われている動的インポートのコードは、現在の画面で使われる場合のみ処理されます。
 
 <script setup>
 import bundlerSvg from '../images/bundler.svg?raw'


### PR DESCRIPTION
ref. #1624

MDNへのリンク3ヶ所、Microsoftの記事へのリンク1ヶ所を日本語版に変更します。