### PR TITLE
fix!: default `build.cssMinify` to `'esbuild'` for SSR

### DIFF
--- a/config/build-options.md
+++ b/config/build-options.md
@@ -130,7 +130,7 @@ CSS コード分割を有効/無効にします。有効にすると、非同期
 ## build.cssMinify
 
 - **型:** `boolean | 'esbuild' | 'lightningcss'`
-- **デフォルト:** [`build.minify`](#build-minify) と同じ
+- **デフォルト:** クライアントは [`build.minify`](#build-minify) と同じで、SSR は `'esbuild'`
 
 このオプションによって、デフォルトの `build.minify` を使うのではなく、CSS ミニファイを具体的に上書きすることで、JS と CSS のミニファイを別々に設定できるようになります。Vite はデフォルトでは `esbuild` を使用して CSS をミニファイしています。`'lightningcss'` を指定すると代わりに [Lightning CSS](https://lightningcss.dev/minification.html) を使用します。指定した場合は、 [`css.lightningcss`](./shared-options.md#css-lightningcss) を使用して設定ができます。
 


### PR DESCRIPTION
resolve #1648

vitejs/vite@f1d3bf7 の migration 以外の反映です
