### PR TITLE
docs: link correctly to vite 5/6 docs versions

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -39,6 +39,10 @@ const additionalTitle = ((): string => {
 const versionLinks = ((): DefaultTheme.NavItemWithLink[] => {
   const oldVersions: DefaultTheme.NavItemWithLink[] = [
     {
+      text: 'Vite 5 ドキュメント',
+      link: 'https://v5.vite.dev',
+    },
+    {
       text: 'Vite 4 ドキュメント',
       link: 'https://v4.vite.dev',
     },
@@ -57,7 +61,7 @@ const versionLinks = ((): DefaultTheme.NavItemWithLink[] => {
     case 'local':
       return [
         {
-          text: 'Vite 5 ドキュメント（リリース）',
+          text: 'Vite 6 ドキュメント（リリース）',
           link: 'https://vite.dev',
         },
         ...oldVersions,


### PR DESCRIPTION
resolve #1755

https://github.com/vitejs/vite/commit/8d5743660f30b7818f473a9f9b6596328aa00918 の反映です。