### PR TITLE
fix!: default `server.cors: false` to disallow fetching from untruste…

### DIFF
--- a/config/server-options.md
+++ b/config/server-options.md
@@ -149,7 +149,7 @@ export default defineConfig({
 - **型:** `boolean | CorsOptions`
 - **デフォルト:** `false`
 
-開発サーバーの CORS を設定します。[オプションオブジェクト](https://github.com/expressjs/cors#configuration-options)を渡して微調整するか、`true` で有効にします。
+開発サーバーの CORS を設定します。[オプションオブジェクト](https://github.com/expressjs/cors#configuration-options)を渡して微調整するか、`true` で任意のオリジンを許可します。
 
 :::warning
 

--- a/config/server-options.md
+++ b/config/server-options.md
@@ -147,8 +147,15 @@ export default defineConfig({
 ## server.cors
 
 - **型:** `boolean | CorsOptions`
+- **デフォルト:** `false`
 
-開発サーバーの CORS を設定します。これはデフォルトで有効になっており、どんなオリジンも許可します。[オプションオブジェクト](https://github.com/expressjs/cors#configuration-options)を渡して微調整するか、`false` で無効にします。
+開発サーバーの CORS を設定します。[オプションオブジェクト](https://github.com/expressjs/cors#configuration-options)を渡して微調整するか、`true` で有効にします。
+
+:::warning
+
+信頼できないオリジンにソースコードを公開するのを避けるため、`true` ではなく特定の値をすることを推奨します。
+:::
+
 
 ## server.headers
 

--- a/guide/backend-integration.md
+++ b/guide/backend-integration.md
@@ -12,6 +12,12 @@
    import { defineConfig } from 'vite'
    // ---cut---
    export default defineConfig({
+     server: {
+       cors: {
+         // ブラウザ経由でアクセスするオリジン
+         origin: 'http://my-backend.example.com',
+       },
+     },
      build: {
        // outDir に .vite/manifest.json を出力
        manifest: true,


### PR DESCRIPTION
resolve #1809

https://github.com/vitejs/vite/commit/b09572acc939351f4e4c50ddf793017a92c678b1 の反映です。


