### PR TITLE
fix: allow CORS from loopback addresses by default

### DIFF
--- a/config/server-options.md
+++ b/config/server-options.md
@@ -161,7 +161,7 @@ export default defineConfig({
 ## server.cors
 
 - **型:** `boolean | CorsOptions`
-- **デフォルト:** `false`
+- **デフォルト:** `{ origin: /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/ }`（localhost, `127.0.0.1`, `::1` を許可）
 
 開発サーバーの CORS を設定します。[オプションオブジェクト](https://github.com/expressjs/cors#configuration-options)を渡して微調整するか、`true` で任意のオリジンを許可します。
 


### PR DESCRIPTION
resolve #1812

https://github.com/vitejs/vite/commit/3d038997377a30022b6a6b7916e0b4b5d8b9a363 の反映です