### PR TITLE
docs: extract introduction section

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -239,7 +239,7 @@ export default defineConfig({
     sidebar: {
       '/guide/': [
         {
-          text: 'はじめに',
+          text: 'イントロダクション',
           items: [
             {
               text: 'はじめに',

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -239,16 +239,25 @@ export default defineConfig({
     sidebar: {
       '/guide/': [
         {
-          text: 'ガイド',
+          text: 'はじめに',
           items: [
-            {
-              text: 'Vite を使う理由',
-              link: '/guide/why',
-            },
             {
               text: 'はじめに',
               link: '/guide/',
             },
+            {
+              text: '理念',
+              link: '/guide/philosophy',
+            },
+            {
+              text: 'Vite を使う理由',
+              link: '/guide/why',
+            },
+          ],
+        },
+        {
+          text: 'ガイド',
+          items: [
             {
               text: '特徴',
               link: '/guide/features',
@@ -300,10 +309,6 @@ export default defineConfig({
             {
               text: 'パフォーマンス',
               link: '/guide/performance',
-            },
-            {
-              text: '理念',
-              link: '/guide/philosophy',
             },
             {
               text: 'v5 からの移行',


### PR DESCRIPTION
resolve #1853

https://github.com/vitejs/vite/commit/3e07b178a334f241b9e6316a1dcf9e110778903a の反映です。

「Introduction」の訳に少し迷っています。原文は「Introduction」と「Getting started」で、今は両方とも「はじめに」と訳してみましたが、2つ同じ名前が並んでいると違和感があるような気もします。

![Screenshot from 2025-02-13 23-13-20](https://github.com/user-attachments/assets/b5f9d07b-f40c-4472-b26b-fbe5d34a5f14)

他に「導入」や「イントロダクション」とも訳せると思いますが、どの訳が一番いいでしょうか？ 🤔 

![Screenshot from 2025-02-13 23-13-38](https://github.com/user-attachments/assets/fd698a2c-8410-499b-92e3-791c3b7ed9c3)

![Screenshot from 2025-02-13 23-13-30](https://github.com/user-attachments/assets/72a2ee27-e6b1-4bdb-b3ed-79d6a9c1aab1)
