### PR TITLE
docs: update to viteconf 2025

### DIFF
--- a/.vitepress/theme/components/AsideSponsors.vue
+++ b/.vitepress/theme/components/AsideSponsors.vue
@@ -21,14 +21,14 @@ const sponsors = computed(() => {
 <template>
   <a
       class="viteconf"
-      href="https://viteconf.org/24/replay?utm=vite-sidebar"
+      href="https://viteconf.org/?utm=vite-sidebar"
       target="_blank"
   >
     <img width="22" height="22" src="/viteconf.svg" alt="ViteConf Logo" />
     <span>
       <p class="extra-info">Building Together</p>
-      <p class="heading">ViteConf 2024</p>
-      <p class="extra-info">リプレイを視聴する！</p>
+      <p class="heading">ViteConf 2025</p>
+      <p class="extra-info">初めて対面で開催！</p>
     </span>
   </a>
   <VPDocAsideSponsors v-if="data" :data="sponsors" />

--- a/.vitepress/theme/components/landing/1. hero-section/HeroSection.vue
+++ b/.vitepress/theme/components/landing/1. hero-section/HeroSection.vue
@@ -5,14 +5,14 @@ import HeroDiagram from './HeroDiagram.vue'
 <template>
   <div class="hero">
     <div class="container">
-      <!-- ViteConf Replay Button -->
+      <!-- ViteConf 2025 Button -->
       <a
-          href="https://viteconf.org/24/replay?utm=vite"
+          href="https://viteconf.org/?utm=vite"
           class="hero__pill"
           target="_blank"
       >
         <img src="/viteconf.svg" alt="Viteconf logo" width="20" height="20" />
-        <span>ViteConf 2024 のトーク</span>
+        <span>ViteConf 2025 のトーク</span>
       </a>
 
       <!-- Heading -->

--- a/.vitepress/theme/components/landing/1. hero-section/HeroSection.vue
+++ b/.vitepress/theme/components/landing/1. hero-section/HeroSection.vue
@@ -12,7 +12,7 @@ import HeroDiagram from './HeroDiagram.vue'
           target="_blank"
       >
         <img src="/viteconf.svg" alt="Viteconf logo" width="20" height="20" />
-        <span>ViteConf 2025 のトーク</span>
+        <span>ViteConf 2025</span>
       </a>
 
       <!-- Heading -->


### PR DESCRIPTION
resolve #1881

https://github.com/vitejs/vite/commit/cc2d623dca58ca3e006ecb1ffda89c16373bd20c の反映です。

`AsideSponsors`のバナーはこのような感じで表示されます。

![screenshot of new banner on sidebar](https://github.com/user-attachments/assets/81cca508-e3c0-4c82-9809-694b6a757865)
