### PR TITLE
docs: `server.https` option is always an options object

### DIFF
--- a/config/preview-options.md
+++ b/config/preview-options.md
@@ -60,9 +60,9 @@ export default defineConfig({
 - **型:** `https.ServerOptions`
 - **デフォルト:** [`server.https`](./server-options#server-https)
 
-TLS + HTTP/2 を有効にします。[`server.proxy` オプション](./server-options#server-proxy)も使用されている場合にのみ TLS にダウングレードされるので注意してください。
+TLS + HTTP/2 を有効にします。
 
-この値は `https.createServer()` に渡される[オプションオブジェクト](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener)でも構いません。
+詳しくは [`server.https`](./server-options#server-https) を参照してください。
 
 ## preview.open
 

--- a/config/server-options.md
+++ b/config/server-options.md
@@ -90,9 +90,9 @@ HTTPS を使用する場合は、このチェックはスキップされます�
 
 - **型:** `https.ServerOptions`
 
-TLS + HTTP/2 を有効にします。[`server.proxy` オプション](#server-proxy)も使用されている場合にのみ TLS にダウングレードされるので注意してください。
+TLS + HTTP/2 を有効にします。この値は `https.createServer()` に渡される[オプションオブジェクト](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener)です。
 
-この値は `https.createServer()` に渡される[オプションオブジェクト](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener)でも構いません。
+TLS にダウングレードされるのは、[`server.proxy` オプション](#server-proxy)も使用している場合のみであることに注意してください。
 
 有効な証明書が必要です。基本的なセットアップでは、自己署名証明書を自動的に作成しキャッシュする [@vitejs/plugin-basic-ssl](https://github.com/vitejs/vite-plugin-basic-ssl) をプロジェクトのプラグインに追加することもできます。しかし、独自の証明書を作成することを推奨します。
 


### PR DESCRIPTION
resolve #1883

https://github.com/vitejs/vite/commit/48151b3e3e522e1d9bb63bcb625a003cced41653 の反映です。
