### PR TITLE
docs: fix broken link to shared-plugins-during-build section

### DIFF
--- a/changes/shared-plugins-during-build.md
+++ b/changes/shared-plugins-during-build.md
@@ -4,7 +4,7 @@
 [Environment API feedback discussion](https://github.com/vitejs/vite/discussions/16358)でフィードバックをお寄せください。
 :::
 
-[ビルド時の共有プラグイン](/guide/api-environment.md#shared-plugins-during-build)を参照してください。
+[ビルド時の共有プラグイン](/guide/api-environment-plugins.md#shared-plugins-during-build)を参照してください。
 
 影響範囲: `Vite プラグイン作成者`
 


### PR DESCRIPTION
resolve #1900

https://github.com/vitejs/vite/commit/eef06035a51701d2c25e3359ae308ea2ffb5dbbc の反映です。
