### PR TITLE
docs: remove deprecated folder mapping exports warning

### DIFF
--- a/config/shared-options.md
+++ b/config/shared-options.md
@@ -140,10 +140,6 @@ SSR ビルドの場合、`build.rollupOptions.output` で設定された ESM ビ
 
 要件が満たされている場合は、`import`、`require`、`default` の条件が常に適用されることに注意してください。
 
-:::warning サブパスのエクスポートの解決
-エクスポートのキーが "/" で終わるのは Node では非推奨で、うまく動作しない可能性があります。代わりに [`*` サブパスパターン](https://nodejs.org/api/packages.html#package-entry-points) を使用するよう、パッケージ作者に連絡してください。
-:::
-
 ## resolve.mainFields
 
 - **型:** `string[]`


### PR DESCRIPTION
resolve #1908

https://github.com/vitejs/vite/commit/93d639e13e17332f2d437dee3aeeab4d980c3eb5 の反映です。
