### PR TITLE
docs: image svg element use href attribute

### DIFF
--- a/guide/features.md
+++ b/guide/features.md
@@ -176,7 +176,7 @@ HTML ファイルは、Vite プロジェクトの[中心](/guide/#index-html-and
 - `<audio src>`
 - `<embed src>`
 - `<img src>` と `<img srcset>`
-- `<image src>`
+- `<image href>` と `<image xlink:href>`
 - `<input src>`
 - `<link href>` と `<link imagesrcset>`
 - `<object data>`


### PR DESCRIPTION
resolve #1964

https://github.com/vitejs/vite/commit/7332e9e1fdc7d9f5b3b3201d70ad40cc520c9c78 の反映です。
