### PR TITLE
feat!: bump `build.target` and name it `baseline-widely-available`

### DIFF
--- a/config/build-options.md
+++ b/config/build-options.md
@@ -5,10 +5,10 @@
 ## build.target
 
 - **型:** `string | string[]`
-- **デフォルト:** `'modules'`
+- **デフォルト:** `'baseline-widely-available'`
 - **関連:** [ブラウザーの互換性](/guide/build#browser-compatibility)
 
-最終的なバンドルのブラウザー互換性のターゲット。デフォルトは Vite の特別な値 `'modules'` で、これは[ネイティブ ES モジュール](https://caniuse.com/es6-module)、[ネイティブ ESM の動的インポート](https://caniuse.com/es6-module-dynamic-import)、[`import.meta`](https://caniuse.com/mdn-javascript_operators_import_meta)をサポートするブラウザーを対象にします。Vite は `'modules'` を `['es2020', 'edge88', 'firefox78', 'chrome87', 'safari14']` へ置き換えます。
+最終的なバンドルのブラウザー互換性のターゲット。デフォルトは Vite の特別な値 `'baseline-widely-available'` で、これは [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available on 2025-05-01 に含まれるブラウザーを対象にします。具体的には `['chrome107', 'edge107', 'firefox104', 'safari16']` です。
 
 もうひとつの特別な値は `'esnext'` で、これはネイディブの動的インポートをサポートしていることを前提としており、最小限のトランスパイルのみが実行されます。
 

--- a/guide/build.md
+++ b/guide/build.md
@@ -4,14 +4,14 @@
 
 ## ブラウザーの互換性 {#browser-compatibility}
 
-デフォルトでは、プロダクションバンドルでは[ネイティブ ES モジュール](https://caniuse.com/es6-module)、[ネイティブ ESM の動的インポート](https://caniuse.com/es6-module-dynamic-import)、[`import.meta`](https://caniuse.com/mdn-javascript_operators_import_meta)、[Null 合体演算子](https://caniuse.com/mdn-javascript_operators_nullish_coalescing)、[BigInt](https://caniuse.com/bigint) といったモダンな JavaScript のサポートを前提としています。デフォルトのブラウザーサポート範囲は次のとおりです:
+デフォルトでは、プロダクションバンドルは [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available ターゲットに含まれるモダンなブラウザーを前提としています。デフォルトのブラウザーサポート範囲は次のとおりです:
 
-<!-- Search for the `ESBUILD_MODULES_TARGET` constant for more information -->
+<!-- Search for the `ESBUILD_BASELINE_WIDELY_AVAILABLE_TARGET` constant for more information -->
 
-- Chrome >=87
-- Firefox >=78
-- Safari >=14
-- Edge >=88
+- Chrome >=107
+- Edge >=107
+- Firefox >=104
+- Safari >=16
 
 [`build.target` 設定オプション](/config/build-options.md#build-target)を介してカスタムターゲットを指定でき、最も低いターゲットは `es2015` です。より低いターゲットが設定された場合、Vite は[ネイティブ ESM の動的インポート](https://caniuse.com/es6-module-dynamic-import)と [`import.meta`](https://caniuse.com/mdn-javascript_operators_import_meta) に依存するため、以下の最小ブラウザサポート範囲が必要です:
 

--- a/guide/index.md
+++ b/guide/index.md
@@ -22,7 +22,7 @@ Vite は完全な型サポートのある [Plugin API](./api-plugin) と [JavaSc
 
 開発中、Vite は [`esnext` を変換ターゲットとして](https://esbuild.github.io/api/#target)設定します。これは、最新のブラウザーが使用され、最新の JavaScript および CSS 機能がすべてサポートされていることが前提となっているためです。これによりシンタックスの低下を防ぎ、Vite が元のソースコードにできるだけ近いモジュールを提供できるようになります。
 
-本番ビルドの場合、Vite はデフォルトで [ネイティブ ES モジュール](https://caniuse.com/es6-module)、[ネイティブ ESM 動的インポート](https://caniuse.com/es6-module-dynamic-import)、[`import.meta`](https://caniuse.com/mdn-javascript_operators_import_meta)、[Null 合体演算子](https://caniuse.com/mdn-javascript_operators_nullish_coalescing)、[BigInt](https://caniuse.com/bigint) などのモダンな JavaScript をサポートするブラウザーをターゲットとします。レガシーブラウザーは、公式の [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) を通じてサポートできます。詳細については、[本番環境用のビルド](./build)セクションを参照してください。
+本番ビルドの場合、Vite はデフォルトで [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available ブラウザーをターゲットとします。これらは少なくとも 2.5 年以上前にリリースされたブラウザーです。ターゲットは設定によって下げることができます。さらに、レガシーブラウザーは公式の [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) を通じてサポートできます。詳細については、[本番環境用のビルド](./build)セクションを参照してください。
 
 ## Vite をオンラインで試す {#trying-vite-online}
 


### PR DESCRIPTION
resolve #1967

https://github.com/vitejs/vite/commit/4a8aa82556eb2b9e54673a6aac77873e0eb27fa9 の反映です