### PR TITLE
docs(rolldown): fix regex pattern in withFilter example for SVG imports

### DIFF
--- a/guide/rolldown.md
+++ b/guide/rolldown.md
@@ -126,7 +126,7 @@ export default defineConfig({
       svgr({
         /*...*/
       }),
-      { load: { id: /\.svg?react$/ } },
+      { load: { id: /\.svg\?react$/ } },
     ),
   ],
 })


### PR DESCRIPTION
resolve #1986

https://github.com/vitejs/vite/commit/a72b3d9c4d1746ce786b37a48f93750c9c0b59bd の反映です