### PR TITLE
docs: fix redundant "yet" and add missing punctuation

### DIFF
--- a/changes/hotupdate-hook.md
+++ b/changes/hotupdate-hook.md
@@ -9,12 +9,12 @@
 影響範囲: `Vite プラグイン作成者`
 
 ::: warning 将来の廃止予定
-`hotUpdate` は `v6.0` で初めて導入されました。`handleHotUpdate` の廃止は将来のメジャーバージョンで予定されています。現時点では、まだ `handleHotUpdate` からの移行は推奨していません。もし実験して私たちにフィードバックをしたいのであれば、vite config で `future.removePluginHookHandleHotUpdate` を `"warn"` に指定してください。
+`hotUpdate` は `v6.0` で初めて導入されました。`handleHotUpdate` の廃止は将来のメジャーバージョンで予定されています。現時点では `handleHotUpdate` からの移行は推奨していません。もし実験して私たちにフィードバックをしたいのであれば、vite config で `future.removePluginHookHandleHotUpdate` を `"warn"` に指定してください。
 :::
 
 ## 動機
 
-[`handleHotUpdate` フック](/guide/api-plugin.md#handlehotupdate) はカスタム HMR 更新処理を行うことができます。更新するモジュールのリストは `HmrContext` に渡されます
+[`handleHotUpdate` フック](/guide/api-plugin.md#handlehotupdate) はカスタム HMR 更新処理を行うことができます。更新するモジュールのリストは `HmrContext` に渡されます。
 
 ```ts
 interface HmrContext {


### PR DESCRIPTION
resolve #2104

https://github.com/vitejs/vite/commit/3c961ecaaa2b42d6bbc8e8db381ddc1d6ccdc489 の反映です
