### PR TITLE
docs: fix `buildApp` type mismatch in code example

### DIFF
--- a/guide/api-environment-frameworks.md
+++ b/guide/api-environment-frameworks.md
@@ -315,7 +315,7 @@ export default {
   builder: {
     buildApp: async (builder) => {
       const environments = Object.values(builder.environments)
-      return Promise.all(
+      await Promise.all(
         environments.map((environment) => builder.build(environment)),
       )
     },


### PR DESCRIPTION
resolve #2155

https://github.com/vitejs/vite/commit/c095037129d44a4991f57172a2eadbd2e45c6543 の反映です
