### PR TITLE
chore(deps): update dependency markdown-it-image-size to v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "feed": "^5.1.0",
     "gsap": "^3.13.0",
     "lint-staged": "^16.2.3",
-    "markdown-it-image-size": "^14.9.0",
+    "markdown-it-image-size": "^15.0.1",
     "textlint": "^13.4.1",
     "textlint-filter-rule-allowlist": "^4.0.0",
     "textlint-filter-rule-comments": "^1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^16.2.3
         version: 16.2.3
       markdown-it-image-size:
-        specifier: ^14.9.0
-        version: 14.9.0(markdown-it@14.1.0)
+        specifier: ^15.0.1
+        version: 15.0.1(markdown-it@14.1.0)
       textlint:
         specifier: ^13.4.1
         version: 13.4.1
@@ -1603,8 +1603,8 @@ packages:
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
 
-  markdown-it-image-size@14.9.0:
-    resolution: {integrity: sha512-2JHjZKDRNeNeRWBHQ5a5dqSuS96rEkGJaOerecxiH2GzO4LYt4GUuITihDpnL7lkJoUzthciu6XPS6W/RiO3VQ==}
+  markdown-it-image-size@15.0.1:
+    resolution: {integrity: sha512-qnnnYtXXdUsBtNyywsMpgXDGi0X4Judba0+MJFGa2GrKrE9zwWlng+3GWlv2uRRtM0BO/le3G6x1Xw/iCjiT5g==}
     engines: {node: '>= 20'}
     peerDependencies:
       markdown-it: '>= 10 < 15'
@@ -4338,7 +4338,7 @@ snapshots:
 
   mark.js@8.11.1: {}
 
-  markdown-it-image-size@14.9.0(markdown-it@14.1.0):
+  markdown-it-image-size@15.0.1(markdown-it@14.1.0):
     dependencies:
       '@types/markdown-it': 14.1.2
       flat-cache: 6.1.17


### PR DESCRIPTION
resolve #2178

https://github.com/vitejs/vite/commit/74dca990b1b26e37c7d1fc3d3ae87667faaf8fbe の反映です
