### PR TITLE
docs: add link to tinyglobby syntax docs

### DIFF
--- a/config/dep-optimization-options.md
+++ b/config/dep-optimization-options.md
@@ -10,7 +10,7 @@
 
 デフォルトでは、Vite はすべての `.html` ファイルをクロールして、事前にバンドルする必要のある依存関係を検出します（`node_modules`, `build.outDir`, `__tests__` および `coverage` は無視します）。`build.rollupOptions.input` が指定されている場合、Vite は代わりにそれらのエントリーポイントをクロールします。
 
-これらのいずれもニーズに合わない場合、このオプションを使ってカスタムエントリーを指定することができます。値は Vite プロジェクトルートからの相対的な [`tinyglobby` パターン](https://github.com/SuperchupuDev/tinyglobby) か、パターンの配列でなければいけません。これによりデフォルトのエントリーの推論が上書きされます。`optimizeDeps.entries` が明示的に定義されている場合、デフォルトでは `node_modules` と `build.outDir` フォルダーのみが無視されます。他のフォルダーを無視したい場合は、最初の `!` でマークした無視パターンをエントリーリストの一部として使用できます。`node_modules` を明示的に含むパターンに対しては、`node_modules` は無視されません。
+これらのいずれもニーズに合わない場合、このオプションを使ってカスタムエントリーを指定することができます。値は Vite プロジェクトルートからの相対的な [`tinyglobby` パターン](https://superchupu.dev/tinyglobby/comparison) か、パターンの配列でなければいけません。これによりデフォルトのエントリーの推論が上書きされます。`optimizeDeps.entries` が明示的に定義されている場合、デフォルトでは `node_modules` と `build.outDir` フォルダーのみが無視されます。他のフォルダーを無視したい場合は、最初の `!` でマークした無視パターンをエントリーリストの一部として使用できます。`node_modules` を明示的に含むパターンに対しては、`node_modules` は無視されません。
 
 ## optimizeDeps.exclude <NonInheritBadge />
 

--- a/config/server-options.md
+++ b/config/server-options.md
@@ -233,7 +233,7 @@ Direct websocket connection fallback. Check out https://vite.dev/config/server-o
 
 変換するファイルをウォームアップし、結果を事前にキャッシュします。これにより、サーバー起動時の初期ページ読み込みが改善され、変換ウォーターフォールを防げます。
 
-`clientFiles` はクライアントのみで使用されるファイルであり、`ssrFiles` は SSR のみで使用されるファイルです。これらは `root` を基準としたファイルパスや [`tinyglobby`](https://github.com/SuperchupuDev/tinyglobby) パターンの配列を受け入れます。
+`clientFiles` はクライアントのみで使用されるファイルであり、`ssrFiles` は SSR のみで使用されるファイルです。これらは `root` を基準としたファイルパスや [`tinyglobby` パターン](https://superchupu.dev/tinyglobby/comparison) の配列を受け入れます。
 
 起動時に Vite 開発サーバーに負荷がかからないように、頻繁に使用するファイルのみを追加するようにしてください。
 

--- a/guide/features.md
+++ b/guide/features.md
@@ -619,7 +619,7 @@ const modulesWithBase = {
 
 - これは Vite のみの機能で、Web または ES の標準ではありません。
 - Glob パターンはインポート指定子のように扱われます。相対パス（`./` で始まる）か絶対パス（`/` で始まり、プロジェクトルートに対して相対的に解決される）、またはエイリアスのパス（[`resolve.alias` オプション](/config/shared-options.md#resolve-alias) 参照）のいずれかでなければなりません。
-- Glob のマッチングは [`tinyglobby`](https://github.com/SuperchupuDev/tinyglobby) を介して行われます。
+- Glob のマッチングは [`tinyglobby`](https://github.com/SuperchupuDev/tinyglobby) を介して行われます - [サポートされている glob パターン](https://superchupu.dev/tinyglobby/comparison)についてはドキュメントを確認してください。
 - また、`import.meta.glob` の引数はすべて**リテラル構文として渡さなければならない**ことに注意が必要です。変数や式は使えません。
 
 ## Dynamic Import


### PR DESCRIPTION
resolve #2200

https://github.com/vitejs/vite/commit/4bcfc646cfbf05650d8e9bf2d4c580150d3aa129 の反映です
