### PR TITLE
docs: clarify the values are escaped automatically

### DIFF
--- a/guide/api-plugin.md
+++ b/guide/api-plugin.md
@@ -387,6 +387,9 @@ Vite プラグインは Vite 特有の目的を果たすフックを提供する
 
   interface HtmlTagDescriptor {
     tag: string
+    /**
+     * 属性の値は必要に応じて自動的にエスケープされます
+     */
     attrs?: Record<string, string | boolean>
     children?: string | HtmlTagDescriptor[]
     /**


### PR DESCRIPTION
resolve #2216

https://github.com/vitejs/vite/commit/246df134dd58441e1e40dd361cf42419d05ea7a5 の反映です
