### PR TITLE
docs: remove broken `build.license` example

### DIFF
--- a/config/build-options.md
+++ b/config/build-options.md
@@ -212,8 +212,6 @@ export default defineConfig({
 ]
 ```
 
-:::
-
 ## build.manifest
 
 - **型:** `boolean | string`


### PR DESCRIPTION
resolve #2238

https://github.com/vitejs/vite/commit/e1c43e0047beb9c43b59e9df3a366483e010ea0b の反映です
