### PR TITLE
docs: `alwaysStrict` does not affect the build result anymore

### DIFF
--- a/guide/features.md
+++ b/guide/features.md
@@ -123,7 +123,6 @@ Vite は `esbuild` と同じ動作に従い、`tsconfig.json` 内の `target` �
 - [`jsxFragmentFactory`](https://www.typescriptlang.org/tsconfig#jsxFragmentFactory)
 - [`jsxImportSource`](https://www.typescriptlang.org/tsconfig#jsxImportSource)
 - [`experimentalDecorators`](https://www.typescriptlang.org/tsconfig#experimentalDecorators)
-- [`alwaysStrict`](https://www.typescriptlang.org/tsconfig#alwaysStrict)
 
 ::: tip `skipLibCheck`
 Vite のスターターテンプレートでは依存関係の型チェックを避けるため、デフォルトで `"skipLibCheck": "true"` となっています。これは TypeScript の特定のバージョンや設定のみをサポートするように選択できるようにするためです。詳しくは [vuejs/vue-cli#5688](https://github.com/vuejs/vue-cli/pull/5688) を参照してください。


### PR DESCRIPTION
resolve #2264 

https://github.com/vitejs/vite/commit/f596aa2cb974fb56d92c4812e26604c7d2998d1a の反映です