### PR TITLE
docs: fix parseAst deprecation replacement names in migration guide

### DIFF
--- a/guide/migration.md
+++ b/guide/migration.md
@@ -372,7 +372,7 @@ const plugin = {
   - `resolveImportMeta` フック（[rolldown#1010](https://github.com/rolldown/rolldown/issues/1010)）
   - `renderDynamicImport` フック（[rolldown#4532](https://github.com/rolldown/rolldown/issues/4532)）
   - `resolveFileUrl` フック
-- `parseAst` / `parseAstAsync` 関数は、より多くの機能を持つ `parse` / `parseAsync` 関数に置き換えられ、非推奨となりました。
+- `parseAst` / `parseAstAsync` 関数は、より多くの機能を持つ `parseSync` / `parse` 関数に置き換えられ、非推奨となりました。
 
 ## v6 からの移行
 


### PR DESCRIPTION
resolve #2318

https://github.com/vitejs/vite/commit/36d936117cfd0ca86586d910188728dd5b1ba81d の反映です
