### PR TITLE
docs: add Scrimba tutorial links across documentation

### DIFF
--- a/.vitepress/theme/components/ScrimbaLink.vue
+++ b/.vitepress/theme/components/ScrimbaLink.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+defineProps<{
+  href: string
+  title: string
+}>()
+</script>
+
+<template>
+  <div class="scrimba">
+    <span class="play-button">
+      <span class="play-icon"></span>
+    </span>
+    <a :href="href" target="_blank" rel="sponsored noopener" :title="title">
+      <slot>Scrimba でインタラクティブなレッスンを見る</slot>
+    </a>
+  </div>
+</template>
+
+<style scoped>
+.scrimba {
+  margin: 16px 0;
+  color: var(--vp-custom-block-info-text);
+  background-color: var(--vp-custom-block-info-bg);
+  border: 1px solid var(--vp-custom-block-info-border);
+  padding: 16px 20px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.play-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  min-width: 26px;
+  border-radius: 50%;
+  background-color: var(--vp-c-brand-1);
+}
+.play-icon {
+  width: 0;
+  height: 0;
+  margin-left: 2px;
+  border-style: solid;
+  border-width: 5px 0 5px 8px;
+  border-color: transparent transparent transparent #fff;
+}
+.scrimba a {
+  color: var(--vp-c-brand-1);
+  text-decoration: underline;
+}
+.scrimba a:hover {
+  color: var(--vp-c-brand-2);
+}
+</style>

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -10,6 +10,7 @@ import SvgImage from './components/SvgImage.vue'
 import YouTubeVideo from './components/YouTubeVideo.vue'
 import NonInheritBadge from './components/NonInheritBadge.vue'
 import AsideSponsors from './components/AsideSponsors.vue'
+import ScrimbaLink from './components/ScrimbaLink.vue'
 
 export default {
   Layout() {
@@ -23,6 +24,7 @@ export default {
     app.component('SvgImage', SvgImage)
     app.component('YouTubeVideo', YouTubeVideo)
     app.component('NonInheritBadge', NonInheritBadge)
+    app.component('ScrimbaLink', ScrimbaLink)
     app.use(TwoslashFloatingVue)
 
     Theme.enhanceApp(ctx)

--- a/config/index.md
+++ b/config/index.md
@@ -22,6 +22,8 @@ export default {
 vite --config my-config.js
 ```
 
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~05jg?via=vite" title="Configuring Vite">Scrimba でインタラクティブなレッスンを見る</ScrimbaLink>
+
 ::: tip 設定の読み込み
 デフォルトでは、Vite は [Rolldown](https://rolldown.rs/) を使用して設定を一時ファイルにバンドルし、読み込みます。これはモノレポ内で TypeScript をインポートする際に問題を引き起こす可能性があります。このアプローチで問題が起きた場合は、代わりに [module runner](/guide/api-environment-runtimes.html#modulerunner) を使用するように `--configLoader runner` を指定できます。これにより、一時的な設定が作成されなくなり、すべてのファイルがその場で変換されるようになります。モジュールランナーは設定ファイル内では CJS をサポートしていませんが、外部の CJS パッケージは通常通りに機能するはずです。
 

--- a/guide/build.md
+++ b/guide/build.md
@@ -2,6 +2,8 @@
 
 作成したアプリケーションを本番環境にデプロイするには、`vite build` コマンドを実行するだけです。デフォルトでは、ビルドのエントリーポイントとして `<root>/index.html` を使用し、静的ホスティングサービスで提供するのに適したアプリケーションバンドルを生成します。一般的なサービスについてのガイドは [静的サイトのデプロイ](./static-deploy) をご覧ください。
 
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~037q?via=vite" title="Building for Production">Scrimba でインタラクティブなレッスンを見る</ScrimbaLink>
+
 ## ブラウザーの互換性 {#browser-compatibility}
 
 デフォルトでは、プロダクションバンドルは [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available ターゲットに含まれるモダンなブラウザーを前提としています。デフォルトのブラウザーサポート範囲は次のとおりです:

--- a/guide/env-and-mode.md
+++ b/guide/env-and-mode.md
@@ -13,6 +13,8 @@ if (import.meta.env.DEV) {
 
 :::
 
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~05an?via=vite" title="Env Variables in Vite">Scrimba でインタラクティブなレッスンを見る</ScrimbaLink>
+
 ## ビルトイン定数
 
 いくつかのビルトイン定数は全てのケースで利用可能です:

--- a/guide/features.md
+++ b/guide/features.md
@@ -367,6 +367,8 @@ CSS Modules を設定するには、[`css.modules`](../config/shared-options.md#
 
 ## 静的アセット
 
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~05pq?via=vite" title="Static Assets in Vite">Scrimba でインタラクティブなレッスンを見る</ScrimbaLink>
+
 静的アセットをインポートすると、提供時に解決されたパブリック URL が返されます:
 
 ```js twoslash

--- a/guide/index.md
+++ b/guide/index.md
@@ -18,6 +18,8 @@ Vite は完全な型サポートのある [Plugin API](./api-plugin) と [JavaSc
 
 プロジェクトの背景にある基本原理について、[Vite を使う理由](./why) セクションで詳しく知ることができます。
 
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq?via=vite" title="Free Vite Course on Scrimba">Scrimba でインタラクティブなチュートリアルを使って Vite を学ぶ</ScrimbaLink>
+
 ## ブラウザー対応
 
 開発中、Vite はモダンブラウザーが使用され、最新の JavaScript および CSS 機能のほとんどをサポートしていることを前提としています。そのため、Vite は [`esnext` を変換ターゲットとして](https://esbuild.github.io/api/#target)設定します。これによりシンタックスの低下を防ぎ、Vite が元のソースコードにできるだけ近いモジュールを提供できるようになります。Vite は開発サーバーを動作させるためにいくつかのランタイムコードを注入します。これらのコードは、各メジャーリリース時点の [Baseline](https://web-platform-dx.github.io/web-features/) Newly Available に含まれる機能を使用します (このメジャーリリースでは 2026-01-01)。
@@ -68,6 +70,8 @@ $ deno init --npm vite
 :::
 
 あとは画面表示に従ってください！
+
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~0yhj?via=vite" title="Scaffolding Your First Vite Project">Scrimba でインタラクティブなレッスンを見る</ScrimbaLink>
 
 ::: tip 互換性について
 Vite は [Node.js](https://nodejs.org/en/) 20.19+, 22.12+ のバージョンが必要です。ただし、一部のテンプレートではそれ以上のバージョンの Node.js を必要としますので、パッケージマネージャーが警告を出した場合はアップグレードしてください。

--- a/guide/using-plugins.md
+++ b/guide/using-plugins.md
@@ -2,6 +2,8 @@
 
 Vite はプラグインを使っての拡張が可能で、Rollup の優れた設計のプラグインインターフェイスに基づいて、 Vite 固有のオプションがいくつか追加されています。つまり、 Vite ユーザーは Rollup プラグインの成熟したエコシステムを利用しながら、必要に応じて開発サーバーや SSR 機能を拡張することができます。
 
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~0y4g?via=vite" title="Using Plugins in Vite">Scrimba でインタラクティブなレッスンを見る</ScrimbaLink>
+
 ## プラグインの追加
 
 プラグインを使うには、プロジェクトの `devDependencies` に追加し、 `vite.config.js` 設定ファイルの `plugins` 配列に含める必要があります。例えば、レガシーブラウザーのサポートを提供するには、公式の [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) が使えます:


### PR DESCRIPTION
resolve #2374

https://github.com/vitejs/vite/commit/2c00fa9e14c512948e1991ae8f846d86e4193f18 の反映です