### PR TITLE
enhance(theme): Use IBM Plex Sans JP for Japanese text

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -102,6 +102,10 @@ const config = defineConfig({
       { rel: 'alternate', type: 'application/rss+xml', href: '/blog.rss' },
     ],
     ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
+    //#region 日本語版独自: Google Fonts から IBM Plex Sans JP を追加
+    ['link', { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' }],
+    ['link', { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+JP:wght@400;500;600;700&display=swap' }],
+    //#endregion
     inlineScript('banner.js'),
     ['link', { rel: 'me', href: 'https://m.webtoo.ls/@vite' }],
     ['meta', { property: 'og:type', content: 'website' }],

--- a/.vitepress/theme/styles.css
+++ b/.vitepress/theme/styles.css
@@ -16,3 +16,12 @@
 :root[data-theme='light'][data-variant='vite'] {
   --color-brand: #6b1eb9;
 }
+
+/*
+ * 日本語用フォントを追加してテーマのフォントをオーバーライド。
+ * 本体のフォント指定が変更された場合は、ここも合わせて修正する。
+ */
+:root {
+  --font-heading: "APK Protocol", "IBM Plex Sans JP", sans-serif;
+  --font-sans: Inter, "IBM Plex Sans JP", sans-serif;
+}


### PR DESCRIPTION
resolve #2379 <!-- `2000` の部分を実際の issue 番号に書き換えてください -->

Google FontsからIBM Plex Sans JPを参照する方法で日本語フォントの導入を行いました。もとのフォントが対応している文字（英語など）はそちらが優先されます。
サブセット化による配信サイズ削減のこともあるので、可能であればセルフホストするよりこちらのほうが良いかと思います。