### PR TITLE
refactor: use `import.meta.dirname` everywhere

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -79,7 +79,7 @@ function inlineScript(file: string): HeadConfig {
     'script',
     {},
     fs.readFileSync(
-      path.resolve(__dirname, `./inlined-scripts/${file}`),
+      path.resolve(import.meta.dirname, `./inlined-scripts/${file}`),
       'utf-8',
     ),
   ]

--- a/guide/api-environment-frameworks.md
+++ b/guide/api-environment-frameworks.md
@@ -52,10 +52,7 @@ if (isRunnableDevEnvironment(server.environments.ssr)) {
 ```js
 import fs from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { createServer } from 'vite'
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const viteServer = await createServer({
   server: { middlewareMode: true },
@@ -75,7 +72,7 @@ app.use('*', async (req, res, next) => {
   const url = req.originalUrl
 
   // 1. index.html を読み込む
-  const indexHtmlPath = path.resolve(__dirname, 'index.html')
+  const indexHtmlPath = path.resolve(import.meta.dirname, 'index.html')
   let template = fs.readFileSync(indexHtmlPath, 'utf-8')
 
   // 2. Vite HTML 変換を適用します。これにより、Vite HMR クライアントが挿入され、

--- a/guide/api-javascript.md
+++ b/guide/api-javascript.md
@@ -13,15 +13,12 @@ async function createServer(inlineConfig?: InlineConfig): Promise<ViteDevServer>
 **使用例:**
 
 ```ts twoslash
-import { fileURLToPath } from 'node:url'
 import { createServer } from 'vite'
-
-const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 const server = await createServer({
   // 有効なユーザー設定オプションに `mode` と `configFile` を追加
   configFile: false,
-  root: __dirname,
+  root: import.meta.dirname,
   server: {
     port: 1337,
   },
@@ -210,13 +207,10 @@ async function build(
 
 ```js twoslash [vite.config.js]
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { build } from 'vite'
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url))
-
 await build({
-  root: path.resolve(__dirname, './project'),
+  root: path.resolve(import.meta.dirname, './project'),
   base: '/foo/',
   build: {
     rollupOptions: {

--- a/guide/build.md
+++ b/guide/build.md
@@ -118,24 +118,21 @@ export default defineConfig({
 
 ```js twoslash [vite.config.js]
 import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
-
-const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   build: {
     rolldownOptions: {
       input: {
-        main: resolve(__dirname, 'index.html'),
-        nested: resolve(__dirname, 'nested/index.html'),
+        main: resolve(import.meta.dirname, 'index.html'),
+        nested: resolve(import.meta.dirname, 'nested/index.html'),
       },
     },
   },
 })
 ```
 
-別のルートを指定した場合でも、入力パスを解決する際には `__dirname` が `vite.config.js` ファイルのフォルダーになることに注意してください。そのため、`resolve` の引数に自分の `root` エントリーを追加する必要があります。
+別のルートを指定した場合でも、入力パスを解決する際には `import.meta.dirname` が `vite.config.js` ファイルのフォルダーになることに注意してください。そのため、`resolve` の引数に自分の `root` エントリーを追加する必要があります。
 
 HTML ファイルの場合、Vite は `rolldownOptions.input` オブジェクトのエントリーに指定された名前を無視し、代わりに dist フォルダーに HTML アセットを生成する際にファイルの解決済み ID を尊重することに注意してください。これにより、開発サーバーの動作方法と一貫した構造が保証されます。
 
@@ -149,15 +146,12 @@ HTML ファイルの場合、Vite は `rolldownOptions.input` オブジェクト
 
 ```js twoslash [vite.config.js（単一エントリー）]
 import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
-
-const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   build: {
     lib: {
-      entry: resolve(__dirname, 'lib/main.js'),
+      entry: resolve(import.meta.dirname, 'lib/main.js'),
       name: 'MyLib',
       // 適切な拡張子が追加されます
       fileName: 'my-lib'
@@ -180,17 +174,14 @@ export default defineConfig({
 
 ```js twoslash [vite.config.js（複数エントリー）]
 import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
-
-const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   build: {
     lib: {
       entry: {
-        'my-lib': resolve(__dirname, 'lib/main.js'),
-        secondary: resolve(__dirname, 'lib/secondary.js'),
+        'my-lib': resolve(import.meta.dirname, 'lib/main.js'),
+        secondary: resolve(import.meta.dirname, 'lib/secondary.js'),
       },
       name: 'MyLib',
     },

--- a/guide/ssr.md
+++ b/guide/ssr.md
@@ -68,11 +68,8 @@ SSR をビルドする際、メインサーバーを完全に制御し、Vite �
 ```js{15-18} twoslash [server.js]
 import fs from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import express from 'express'
 import { createServer as createViteServer } from 'vite'
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 async function createServer() {
   const app = express()
@@ -111,7 +108,6 @@ createServer()
 // @noErrors
 import fs from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 
 /** @type {import('express').Express} */
 var app
@@ -125,7 +121,7 @@ app.use('*all', async (req, res, next) => {
   try {
     // 1. index.html を読み込む
     let template = fs.readFileSync(
-      path.resolve(__dirname, 'index.html'),
+      path.resolve(import.meta.dirname, 'index.html'),
       'utf-8',
     )
 


### PR DESCRIPTION
resolve #2384

https://github.com/vitejs/vite/commit/7becf5f8fe9041cff60f495ef975faaba68f9eb2 の反映です