### PR TITLE
docs: revert "docs: remove scrimba link temporarily"

### DIFF
--- a/guide/env-and-mode.md
+++ b/guide/env-and-mode.md
@@ -13,6 +13,8 @@ if (import.meta.env.DEV) {
 
 :::
 
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~05an?via=vite" title="Env Variables in Vite">Scrimba でインタラクティブなレッスンを見る</ScrimbaLink>
+
 ## ビルトイン定数
 
 いくつかのビルトイン定数は全てのケースで利用可能です:


### PR DESCRIPTION
This reverts commit 5d754d56d8ca1432e2fec9585096c976f1c6092f.

resolve #2417 

https://github.com/vitejs/vite/commit/613b847eacc8e5e107eb6a7d0d27c13d545ba6e6 の反映です