### PR TITLE
docs: make `$` non-selectable in the top page commands

Co-authored-by: 翠 <green@sapphi.red> (#2459)

### DIFF
--- a/.vitepress/theme/landing/Hero.vue
+++ b/.vitepress/theme/landing/Hero.vue
@@ -14,11 +14,11 @@ if (typeof document !== 'undefined') {
 }
 
 const installTabs = [
-  { label: 'npm', code: '$ npm create vite@latest' },
-  { label: 'Yarn', code: '$ yarn create vite' },
-  { label: 'pnpm', code: '$ pnpm create vite' },
-  { label: 'Bun', code: '$ bun create vite' },
-  { label: 'Deno', code: '$ deno init --npm vite' },
+  { label: 'npm', code: 'npm create vite@latest', prefix: '$ ' },
+  { label: 'Yarn', code: 'yarn create vite', prefix: '$ ' },
+  { label: 'pnpm', code: 'pnpm create vite', prefix: '$ ' },
+  { label: 'Bun', code: 'bun create vite', prefix: '$ ' },
+  { label: 'Deno', code: 'deno init --npm vite', prefix: '$ ' },
 ]
 </script>
 


### PR DESCRIPTION
resolves #2459
Cherry picked from https://github.com/vitejs/vite/commit/6803be6f0b0b02ffe992cb1097f6706f69fea90c