### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
-    - uses: pnpm/action-setup@v4
-    - uses: actions/setup-node@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: 22
         cache: 'pnpm'

--- a/.github/workflows/ryu-cho.yml
+++ b/.github/workflows/ryu-cho.yml
@@ -9,7 +9,7 @@ jobs:
     name: Ryu Cho
     runs-on: ubuntu-latest
     steps:
-      - uses: vuejs-translations/ryu-cho@v1
+      - uses: vuejs-translations/ryu-cho@0a768f926097fce17a38358243c50003721627fb # v1
         with:
           access-token: ${{ secrets.ACCESS_TOKEN }}
           username: kiaking


### PR DESCRIPTION
## Summary
- 組織ポリシーにより `vitejs/docs-ja` ではすべての GitHub Actions をフルSHAでピン留めする必要があり、現状 `ryu-cho` ワークフローが以下のエラーで失敗している:
  > The action vuejs-translations/ryu-cho@v1 is not allowed in vitejs/docs-ja because all actions must be pinned to a full-length commit SHA.
- エラーに出ている `ryu-cho` だけでなく、同ポリシーの対象になる `lint.yml` 内の `actions/checkout` / `pnpm/action-setup` / `actions/setup-node` も併せてSHA固定に変更。
- 元のタグ名は `# v1` のように末尾コメントとして残してあり、後で Dependabot 等が更新する際の手がかりになる。

## Test plan
- [ ] `Lint` ワークフローが PR 上で成功すること
- [ ] マージ後、`ryu-cho` のスケジュール実行で「must be pinned to a full-length commit SHA」エラーが出なくなること

🤖 Generated with [Claude Code](https://claude.com/claude-code)