### PR TITLE
ci: add explicit GITHUB_TOKEN permissions to CI workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   textlint:
 

--- a/.github/workflows/ryu-cho.yml
+++ b/.github/workflows/ryu-cho.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '*/5 * * * *'
 
+permissions:
+  contents: read
+
 jobs:
   ryu-cho:
     name: Ryu Cho


### PR DESCRIPTION
Each of these workflows runs without a top-level `permissions:` block, so its `GITHUB_TOKEN` inherits the repository (or org) default, which is frequently read/write for all scopes.

Setting `contents: read` explicitly on `.github/workflows/lint.yml`, `.github/workflows/ryu-cho.yml` keeps the workflow token scoped to what the job actually uses. If a third-party action or transitive dependency in the run were ever compromised, a read-only token limits the damage (no pushes, no releases, no token-backed writes). The change is mechanical and does not alter any step.