### PR TITLE
docs: add ios16.4 to the documented baseline-widely-available target …

### DIFF
--- a/config/build-options.md
+++ b/config/build-options.md
@@ -8,7 +8,7 @@
 - **デフォルト:** `'baseline-widely-available'`
 - **関連:** [ブラウザーの互換性](/guide/build#browser-compatibility)
 
-最終的なバンドルのブラウザー互換性のターゲット。デフォルトは Vite の特別な値 `'baseline-widely-available'` で、これは [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available on 2026-01-01 に含まれるブラウザーを対象にします。具体的には `['chrome111', 'edge111', 'firefox114', 'safari16.4']` です。
+最終的なバンドルのブラウザー互換性のターゲット。デフォルトは Vite の特別な値 `'baseline-widely-available'` で、これは [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available on 2026-01-01 に含まれるブラウザーを対象にします。具体的には `['chrome111', 'edge111', 'firefox114', 'safari16.4', 'ios16.4']` です。
 
 もうひとつの特別な値は `'esnext'` で、これはネイディブの動的インポートをサポートしていることを前提としており、最小限のトランスパイルのみが実行されます。
 


### PR DESCRIPTION
resolve #2621

https://github.com/vitejs/vite/commit/d58c470bfa19efa8557d49c4957a92272f911582 の反映です