### PR TITLE
chore(deps): update dependency feed to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/express": "^5.0.6",
     "@types/node": "^24.13.2",
     "@voidzero-dev/vitepress-theme": "^4.8.4",
-    "feed": "^5.2.1",
+    "feed": "^6.0.0",
     "lint-staged": "^17.0.8",
     "markdown-it-image-size": "^15.0.1",
     "oxc-minify": "^0.138.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^4.8.4
         version: 4.8.4(focus-trap@8.0.1)(typescript@6.0.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.9.0))(vitepress@2.0.0-alpha.17(@types/node@24.13.2)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-minify@0.138.0)(postcss@8.5.16)(typescript@6.0.2)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.2))
       feed:
-        specifier: ^5.2.1
-        version: 5.2.1
+        specifier: ^6.0.0
+        version: 6.0.0
       lint-staged:
         specifier: ^17.0.8
         version: 17.0.8
@@ -1571,8 +1571,8 @@ packages:
       picomatch:
         optional: true
 
-  feed@5.2.1:
-    resolution: {integrity: sha512-jTynzYPWs9ALjro0GW8j7sv9y7cJBeOdD4Y88kVqYy/eyusIX3g+499JiTDIlD9Ge/unebx57T4Uzo6vpYvMtA==}
+  feed@6.0.0:
+    resolution: {integrity: sha512-rvFOF1POce0ijAKy3tZN5T8PuprgIit/VbMyXJWcoYwcMOTSIJ7NqZb8DTLPJr77yiEO27kidm/fw0kcSIV+ww==}
     engines: {node: '>=20', pnpm: '>=10'}
 
   file-entry-cache@5.0.1:
@@ -4825,7 +4825,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  feed@5.2.1:
+  feed@6.0.0:
     dependencies:
       xml-js: 1.6.11
 


### PR DESCRIPTION
resolve #2704

https://github.com/vitejs/vite/commit/04175fbcb0074c68d28f76763974ae89941ff03b の反映です