### PR TITLE
docs(static-deploy): fix links for Vercel deployment environments (#22952)

### DIFF
--- a/guide/static-deploy.md
+++ b/guide/static-deploy.md
@@ -162,7 +162,7 @@ Netlify CLI は検査のためにプレビュー URL を共有します。本番
 3. Vercel はあなたが Vite を使用していることを検出し、あなたのデプロイメントのための正しい設定を有効にします。
 4. アプリケーションがデプロイされます！（例: [vite-vue-template.vercel.app](https://vite-vue-template.vercel.app/)）
 
-プロジェクトがインポートされてデプロイされた後は、ブランチへのプッシュはすべて[プレビューデプロイメント](https://vercel.com/docs/concepts/deployments/environments#preview)を生成し、プロダクションブランチ（一般には main）に加えられたすべての変更は[プロダクションデプロイメント](https://vercel.com/docs/concepts/deployments/environments#production)を生成することになります。
+プロジェクトがインポートされてデプロイされた後は、ブランチへのプッシュはすべて[プレビューデプロイメント](https://vercel.com/docs/deployments/environments#preview-environment-pre-production)を生成し、プロダクションブランチ（一般には main）に加えられたすべての変更は[プロダクションデプロイメント](https://vercel.com/docs/deployments/environments#production-environment)を生成することになります。
 
 詳細は Vercel の [Git 統合](https://vercel.com/docs/concepts/git)をご覧ください。
 


### PR DESCRIPTION
resolve #2709

https://github.com/vitejs/vite/commit/0f2e815d14820ad1715022d9c9bf37a089742696 の反映です