### PR TITLE
docs: remove nonexistent `RemoteEnvironmentTransport` import in environment API example

### DIFF
--- a/guide/api-environment-runtimes.md
+++ b/guide/api-environment-runtimes.md
@@ -356,7 +356,7 @@ const runner = new ModuleRunner(
 
 ```js [server.js]
 import { BroadcastChannel } from 'node:worker_threads'
-import { createServer, RemoteEnvironmentTransport, DevEnvironment } from 'vite'
+import { createServer, DevEnvironment } from 'vite'
 
 function createWorkerEnvironment(name, config, context) {
   const worker = new Worker('./worker.js')


### PR DESCRIPTION
resolve #2761

https://github.com/vitejs/vite/commit/40a3999e66b5b51f45ec0ead60265f3b2184e780 の反映です