### PR TITLE
docs: fix broken links in Environment API pages

### DIFF
--- a/changes/ssr-using-modulerunner.md
+++ b/changes/ssr-using-modulerunner.md
@@ -4,7 +4,7 @@
 [Environment API feedback discussion](https://github.com/vitejs/vite/discussions/16358)でフィードバックをお寄せください。
 :::
 
-`server.ssrLoadModule` は [Module Runner](/guide/api-environment#modulerunner) からのインポートに置き換えられました。
+`server.ssrLoadModule` は [Module Runner](/guide/api-environment-runtimes#modulerunner) からのインポートに置き換えられました。
 
 影響範囲: `Vite プラグイン作成者`
 


### PR DESCRIPTION
resolve #2766

https://github.com/vitejs/vite/commit/06cd77f0c6e92586bb727100785a71e65a9a30c1 の反映です