### PR TITLE
docs: explain browser target using words used by baseline-browser-mapping

### DIFF
--- a/blog/announcing-vite7.md
+++ b/blog/announcing-vite7.md
@@ -61,7 +61,7 @@ We require these new ranges so Node.js supports `require(esm)` without a flag. T
 
 ## Default Browser Target Changed to Baseline Widely Available
 
-[Baseline](https://web-platform-dx.github.io/web-features/) gives us clear information about which web platform features work across their core browser set today. Baseline Widely Available indicates the feature is well-established and works across many devices and browser versions, being available across browsers for at least 30 months.
+[Baseline](https://web-platform-dx.github.io/baseline/) gives us clear information about which web platform features work across their core browser set today. Baseline Widely Available indicates the feature is well-established and works across many devices and browser versions, being available across browsers for at least 30 months.
 
 In Vite 7, the default browser target is changing from `'modules'` to a new default: `'baseline-widely-available'`. The set of browsers will be updated on each major to match the list of minimum browser versions compatible with Baseline Widely available features. The default browser value of `build.target` is changing in Vite 7.0:
 

--- a/config/build-options.md
+++ b/config/build-options.md
@@ -8,7 +8,7 @@
 - **デフォルト:** `'baseline-widely-available'`
 - **関連:** [ブラウザーの互換性](/guide/build#browser-compatibility)
 
-最終的なバンドルのブラウザー互換性のターゲット。デフォルトは Vite の特別な値 `'baseline-widely-available'` で、これは [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available on 2026-01-01 に含まれるブラウザーを対象にします。具体的には `['chrome111', 'edge111', 'firefox114', 'safari16.4', 'ios16.4']` です。
+最終的なバンドルのブラウザー互換性のターゲット。デフォルトは Vite の特別な値 `'baseline-widely-available'` で、これはメジャーリリースごとに固定された日付（[このメジャーでは 2026-01-01](https://web-platform-dx.github.io/supported-browsers/?widelyAvailableOnDate=2026-01-01)）時点の [Baseline](https://web-platform-dx.github.io/baseline/) Widely Available と互換性のある最小のブラウザーバージョンを対象にします。具体的には `['chrome111', 'edge111', 'firefox114', 'safari16.4', 'ios16.4']` です。
 
 もうひとつの特別な値は `'esnext'` で、これはネイディブの動的インポートをサポートしていることを前提としており、最小限のトランスパイルのみが実行されます。
 

--- a/guide/build.md
+++ b/guide/build.md
@@ -6,7 +6,7 @@
 
 ## ブラウザーの互換性 {#browser-compatibility}
 
-デフォルトでは、プロダクションバンドルは [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available ターゲットに含まれるモダンなブラウザーを前提としています。デフォルトのブラウザーサポート範囲は次のとおりです:
+デフォルトでは、プロダクションバンドルはメジャーリリースごとに固定された日付時点の [Baseline](https://web-platform-dx.github.io/baseline/) Widely Available と互換性のある最小のブラウザーバージョンをターゲットにします。このメジャーにおけるデフォルトのブラウザーサポート範囲は次のとおりです:
 
 <!-- Search for the `ESBUILD_BASELINE_WIDELY_AVAILABLE_TARGET` constant for more information -->
 

--- a/guide/index.md
+++ b/guide/index.md
@@ -22,9 +22,9 @@ Vite は完全な型サポートのある [Plugin API](./api-plugin) と [JavaSc
 
 ## ブラウザー対応
 
-開発中、Vite はモダンブラウザーが使用され、最新の JavaScript および CSS 機能のほとんどをサポートしていることを前提としています。そのため、Vite は [`esnext` を変換ターゲットとして](https://oxc.rs/docs/guide/usage/transformer/lowering.html#target)設定します。これによりシンタックスの低下を防ぎ、Vite が元のソースコードにできるだけ近いモジュールを提供できるようになります。Vite は開発サーバーを動作させるためにいくつかのランタイムコードを注入します。これらのコードは、各メジャーリリース時点の [Baseline](https://web-platform-dx.github.io/web-features/) Newly Available に含まれる機能を使用します (このメジャーリリースでは 2026-01-01)。
+開発中、Vite はモダンブラウザーが使用され、最新の JavaScript および CSS 機能のほとんどをサポートしていることを前提としています。そのため、Vite は [`esnext` を変換ターゲットとして](https://oxc.rs/docs/guide/usage/transformer/lowering.html#target)設定します。これによりシンタックスの低下を防ぎ、Vite が元のソースコードにできるだけ近いモジュールを提供できるようになります。Vite は開発サーバーを動作させるためにいくつかのランタイムコードを注入します。これらのコードは、各メジャーリリース時点の [Baseline](https://web-platform-dx.github.io/baseline/) Newly Available に含まれる機能を使用します (このメジャーリリースでは 2026-01-01)。
 
-本番ビルドの場合、Vite はデフォルトで [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available ブラウザーをターゲットとします。これらは少なくとも 2.5 年以上前にリリースされたブラウザーです。ターゲットは設定によって下げることができます。さらに、レガシーブラウザーは公式の [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) を通じてサポートできます。詳細については、[本番環境用のビルド](./build)セクションを参照してください。
+本番ビルドの場合、Vite はデフォルトでメジャーリリースごとに固定された日付時点の [Baseline](https://web-platform-dx.github.io/baseline/) Widely Available と互換性のあるブラウザーバージョンをターゲットとします。このメジャーリリースでは、これは[2023年半ば頃にリリースされたブラウザーバージョン](https://web-platform-dx.github.io/supported-browsers/?widelyAvailableOnDate=2026-01-01)に相当します。ターゲットは設定によって下げることができます。さらに、レガシーブラウザーは公式の [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) を通じてサポートできます。詳細については、[本番環境用のビルド](./build)セクションを参照してください。
 
 ## Vite をオンラインで試す {#trying-vite-online}
 

--- a/guide/migration.md
+++ b/guide/migration.md
@@ -11,7 +11,7 @@ v6 および v7 の Vite に統合された Rolldown のテクニカルプレビ
 - Firefox 104 → 114
 - Safari 16.0 → 16.4
 
-これらのブラウザーバージョンは、2026 年 1 月 1 日時点の [Baseline Widely Available](https://web-platform-dx.github.io/web-features/) 機能セットに準拠します。つまり、これらはすべて約 2 年半前にリリースされたものです。
+これらのブラウザーバージョンは、2026 年 1 月 1 日時点の [Baseline Widely Available](https://web-platform-dx.github.io/baseline/) 機能セットに準拠します。つまり、これらはすべて約 2 年半前にリリースされたものです。
 
 ## Rolldown
 


### PR DESCRIPTION
resolve #2769

https://github.com/vitejs/vite/commit/7e221fc61e3f4c57371ce7dc24c51e887ae33157 の反映です