### PR TITLE
docs(migration): import swc in the decorator workaround

### DIFF
--- a/guide/migration.md
+++ b/guide/migration.md
@@ -179,6 +179,7 @@ $ deno add -D npm:@rollup/plugin-swc npm:@swc/core
 
 ```js
 import { defineConfig, withFilter } from 'vite'
+import swc from '@rollup/plugin-swc'
 
 export default defineConfig({
   // ...


### PR DESCRIPTION
resolve #2770

https://github.com/vitejs/vite/commit/e2d47490c931f25fa79fb41f50c23e85b0254e9b の反映です