### PR TITLE
docs(build): correct 'rollup' to 'Rolldown'

### DIFF
--- a/config/build-options.md
+++ b/config/build-options.md
@@ -364,7 +364,7 @@ gzip 圧縮されたサイズレポートを有効/無効にします。大き�
 - **型:** [`WatcherOptions`](https://rolldown.rs/reference/InputOptions.watch)`| null`
 - **デフォルト:** `null`
 
-Rollup ウォッチャーを有効にするには、`{}` に設定します。これは主に、ビルドのみのプラグインや統合プロセスを伴うケースで使用されます。
+Rolldown ウォッチャーを有効にするには、`{}` に設定します。これは主に、ビルドのみのプラグインや統合プロセスを伴うケースで使用されます。
 
 ::: warning Windows Subsystem for Linux (WSL) 2 上での Vite の実行
 

--- a/guide/build.md
+++ b/guide/build.md
@@ -84,7 +84,7 @@ window.addEventListener('vite:preloadError', (event) => {
 
 ## ファイル変更時のリビルド
 
-`vite build --watch` で rollup のウォッチャーを有効にすることができます。 また、`build.watch` を介して基礎となる [`WatcherOptions`](https://rolldown.rs/reference/InputOptions.watch) を直接調整することもできます:
+`vite build --watch` で Rolldown のウォッチャーを有効にすることができます。 また、`build.watch` を介して基礎となる [`WatcherOptions`](https://rolldown.rs/reference/InputOptions.watch) を直接調整することもできます:
 
 ```js [vite.config.js]
 export default defineConfig({


### PR DESCRIPTION
resolve #2777

https://github.com/vitejs/vite/commit/6452703914bb44e4f428864f15dac7df8e31c9b9 の反映です