### PR TITLE
docs: correct the type of `server.middlewareMode`

### DIFF
--- a/config/server-options.md
+++ b/config/server-options.md
@@ -330,10 +330,12 @@ Vite を WSL2 で実行している際、ファイルシステム監視はファ
 
 ## server.middlewareMode
 
-- **型:** `boolean`
+- **型:** `boolean | { server: http.Server }`
 - **デフォルト:** `false`
 
 ミドルウェアモードで Vite サーバーを作成します。
+
+WebSocket 用に [proxy](./server-options#server-proxy) が設定されている場合、プロキシを正しくバインドするために `server` を渡す必要があります。
 
 - **関連:** [appType](./shared-options#apptype), [SSR - 開発サーバーのセットアップ](/guide/ssr#setting-up-the-dev-server)
 


### PR DESCRIPTION
resolve #2784

https://github.com/vitejs/vite/commit/9c75eb1ff075455e91d43729827213a159216c4f の反映です