### PR TITLE
docs: clarify about `server.proxy` WebSocket origin check

### DIFF
--- a/config/server-options.md
+++ b/config/server-options.md
@@ -160,6 +160,12 @@ export default defineConfig({
 })
 ```
 
+::: warning WebSocket のオリジンチェックについて
+
+Vite はプロキシ処理を行う前に WebSocket リクエストのオリジンをチェックしません。プロキシ先で `Origin` ヘッダーなどのチェックを行うことが期待されています。`rewriteWsOrigin` オプションを使用するとオリジンがターゲットのオリジンに書き換えられ、オリジンチェックがバイパスされてしまうことに注意してください。
+
+:::
+
 ## server.cors
 
 - **型:** `boolean | CorsOptions`


### PR DESCRIPTION
resolve #2804

https://github.com/vitejs/vite/commit/16048483f6fb98c237767d26f7bd6028fc6c53b0 の反映です