### PR TITLE
feat(cli): support naming the CPU profile via --profile [name]

### DIFF
--- a/guide/cli.md
+++ b/guide/cli.md
@@ -28,7 +28,7 @@ vite [root]
 | `-l, --logLevel <level>`  | info \| warn \| error \| silent （`string`）                                                             |
 | `--clearScreen`           | ログを表示する際に画面をクリアするかどうか（`boolean`）                                                                       |
 | `--configLoader <loader>` | `bundle`: Rolldown を使用して設定をバンドルする。`runner`（実験的機能）: その場で処理する。`native`（実験的機能）: ネイティブランタイムを使用して読み込む（デフォルト: `bundle`） |
-| `--profile`               | 組み込みの Node.js インスペクターを起動する（[パフォーマンスのボトルネック](/guide/troubleshooting#performance-bottlenecks)を確認してください）  |
+| `--profile [name]`        | 組み込みの Node.js インスペクターを起動し、プロファイルを `<name>.cpuprofile` に書き込む（[パフォーマンスのボトルネック](/guide/troubleshooting#performance-bottlenecks)を確認してください）（`boolean \| string`） |
 | `-d, --debug [feat]`      | デバッグログを表示する（`string \| boolean`）                                                                       |
 | `-f, --filter <filter>`   | デバッグログをフィルタリングする（`string`）                                                                             |
 | `-m, --mode <mode>`       | env モードを設定する（`string`）                                                                                 |
@@ -67,7 +67,7 @@ vite build [root]
 | `-l, --logLevel <level>`       | info \| warn \| error \| silent （`string`）                                                                          |
 | `--clearScreen`                | ログを表示する際に画面をクリアするかどうか（`boolean`）                                                                |
 | `--configLoader <loader>`      | `bundle` で Rolldown を使用して設定をバンドルするか、`runner`（実験的）でその場で処理するか、`native`（実験的）でネイティブランタイムを使用して読み込むか指定する（デフォルト: `bundle`）     |
-| `--profile`                    | 組み込みの Node.js インスペクターを起動する（[パフォーマンスのボトルネック](/guide/troubleshooting#performance-bottlenecks)を確認してください）|
+| `--profile [name]`             | 組み込みの Node.js インスペクターを起動し、プロファイルを `<name>.cpuprofile` に書き込む（[パフォーマンスのボトルネック](/guide/troubleshooting#performance-bottlenecks)を確認してください）（`boolean \| string`） |
 | `-d, --debug [feat]`           | デバッグログを表示する（`string \| boolean`）                                                                              |
 | `-f, --filter <filter>`        | デバッグログをフィルタリングする（`string`）                                                                                       |
 | `-m, --mode <mode>`            | env モードを設定する（`string`）                                                                                            |

--- a/guide/troubleshooting.md
+++ b/guide/troubleshooting.md
@@ -240,7 +240,7 @@ vite build --profile
 アプリケーションをブラウザーで開いたら、読み込みが終わるのを待ち、ターミナルに戻って `p` キーを押し（Node.js インスペクターを停止します）、次に `q` キーを押して開発サーバーを停止します。
 :::
 
-Node.js インスペクターはルートフォルダーに `vite-profile-0.cpuprofile` を生成し、https://www.speedscope.app/ に遷移、`BROWSE` ボタンを使って CPU プロファイルをアップロードし、結果を検証します。
+Node.js インスペクターはルートフォルダーに `vite-profile-0.cpuprofile` を生成します。代わりに `<name>.cpuprofile` を書き込むには `--profile <name>`（または `--profile=<name>`）を渡します。https://www.speedscope.app/ に遷移、`BROWSE` ボタンを使って CPU プロファイルをアップロードし、結果を検証します。
 
 [vite-plugin-inspect](https://github.com/antfu/vite-plugin-inspect) をインストールすると、Vite プラグインの中間状態を検査でき、アプリケーションのボトルネックとなっているプラグインやミドルウェアを特定するのに役立ちます。このプラグインは開発モードとビルドモードの両方で使用できます。詳しくは readme ファイルをご覧ください。
 


### PR DESCRIPTION
resolve #2807

https://github.com/vitejs/vite/commit/a500deeb6f52d93ca501a0fc612a5392b939f2f5 の反映です